### PR TITLE
Feature/#437 settlement window initialization

### DIFF
--- a/seeds/settlement_3_settlementWindow.js
+++ b/seeds/settlement_3_settlementWindow.js
@@ -47,19 +47,16 @@ exports.seed = async function (knex) {
     const settlementWindowStateChangeList = await knex('settlementWindow').select('*')
       .leftJoin('settlementWindowStateChange', 'settlementWindowStateChange.settlementWindowStateChangeId', 'settlementWindow.currentStateChangeId')
       .where('settlementWindowStateChange.settlementWindowStateId', '=', settlementWindowState)
-      if (settlementWindowStateChangeList.length < 1) {
+    if (settlementWindowStateChangeList.length < 1) {
       const settlementWindowId = await knex('settlementWindow').insert(initialSettlementWindow)
       initialSettlementWindowStateChange.settlementWindowId = settlementWindowId
-
       const settlementWindowStateChangeId = await knex('settlementWindowStateChange').insert(initialSettlementWindowStateChange)
-
       await knex('settlementWindow')
-      .where('settlementWindowId', '=', settlementWindowId)
-      .update({
-        currentStateChangeId: settlementWindowStateChangeId
-      })
+        .where('settlementWindowId', '=', settlementWindowId)
+        .update({
+          currentStateChangeId: settlementWindowStateChangeId
+        })
     }
-
     return true
   } catch (err) {
     if (err.code === 'ER_DUP_ENTRY') return -1001

--- a/seeds/settlement_3_settlementWindow.js
+++ b/seeds/settlement_3_settlementWindow.js
@@ -44,22 +44,21 @@ let initialSettlementWindowStateChange = {
 
 exports.seed = async function (knex) {
   try {
-/*    const settlementWindowStateChangeList = await knex ('settlementWindow')
-      .join('settlementWindowStateChange', 'settlementWindowStateChange.settlementWindowStateChangeId', 'settlementWindow.currentStateChangeId')
-      .where('settlementWindowStateChange.settlementWindowStateId', '=', 'settlementWindow.settlementWindowState')
-    console.log(`initial settlementWindow excuted: ${settlementWindowStateChangeList}`)
-    if(settlementWindowStateChangeList === 0)
-*/
-    const settlementWindowId = await knex('settlementWindow').insert(initialSettlementWindow)
-    initialSettlementWindowStateChange.settlementWindowId = settlementWindowId
+    const settlementWindowStateChangeList = await knex('settlementWindow').select('*')
+      .leftJoin('settlementWindowStateChange', 'settlementWindowStateChange.settlementWindowStateChangeId', 'settlementWindow.currentStateChangeId')
+      .where('settlementWindowStateChange.settlementWindowStateId', '=', settlementWindowState)
+      if (settlementWindowStateChangeList.length < 1) {
+      const settlementWindowId = await knex('settlementWindow').insert(initialSettlementWindow)
+      initialSettlementWindowStateChange.settlementWindowId = settlementWindowId
 
-    const settlementWindowStateChangeId = await knex('settlementWindowStateChange').insert(initialSettlementWindowStateChange)
+      const settlementWindowStateChangeId = await knex('settlementWindowStateChange').insert(initialSettlementWindowStateChange)
 
-    await knex('settlementWindow')
+      await knex('settlementWindow')
       .where('settlementWindowId', '=', settlementWindowId)
       .update({
         currentStateChangeId: settlementWindowStateChangeId
       })
+    }
 
     return true
   } catch (err) {

--- a/seeds/settlement_3_settlementWindow.js
+++ b/seeds/settlement_3_settlementWindow.js
@@ -44,6 +44,12 @@ let initialSettlementWindowStateChange = {
 
 exports.seed = async function (knex) {
   try {
+/*    const settlementWindowStateChangeList = await knex ('settlementWindow')
+      .join('settlementWindowStateChange', 'settlementWindowStateChange.settlementWindowStateChangeId', 'settlementWindow.currentStateChangeId')
+      .where('settlementWindowStateChange.settlementWindowStateId', '=', 'settlementWindow.settlementWindowState')
+    console.log(`initial settlementWindow excuted: ${settlementWindowStateChangeList}`)
+    if(settlementWindowStateChangeList === 0)
+*/
     const settlementWindowId = await knex('settlementWindow').insert(initialSettlementWindow)
     initialSettlementWindowStateChange.settlementWindowId = settlementWindowId
 


### PR DESCRIPTION
Updated 'settlement_3_settlementWindow.is' not to create a new settlementWindow if one exist in an open state. Story #437.