### PR TITLE
Fixed helper scripts as per the meeting

### DIFF
--- a/testPI2/util/scripts/monitorKafkaGroupCentralLedger-johnny.sh
+++ b/testPI2/util/scripts/monitorKafkaGroupCentralLedger-johnny.sh
@@ -10,4 +10,4 @@ fi
 echo "Loading env vars..."
 source $CWD/env.sh
 
-docker exec -t $KAFKA_ID sh -c "while true; do ./opt/kafka_2.12-1.1.0/bin/kafka-consumer-groups.sh --bootstrap-server localhost:9092 --group central-ledger-kafka --describe; sleep 5; done"
+docker exec -t $KAFKA_ID sh -c "while true; do ./opt/kafka_2.12-1.1.1/bin/kafka-consumer-groups.sh --bootstrap-server localhost:9092 --group central-ledger-kafka --describe; sleep 5; done"

--- a/testPI2/util/scripts/monitorKafkaGroupMlAPIAdapter-johnny.sh
+++ b/testPI2/util/scripts/monitorKafkaGroupMlAPIAdapter-johnny.sh
@@ -10,4 +10,4 @@ fi
 echo "Loading env vars..."
 source $CWD/env.sh
 
-docker exec -t $KAFKA_ID sh -c "while true; do ./opt/kafka_2.12-1.1.0/bin/kafka-consumer-groups.sh --bootstrap-server localhost:9092 --group kafka-ml-api-adapter --describe; sleep 5; done"
+docker exec -t $KAFKA_ID sh -c "while true; do ./opt/kafka_2.12-1.1.1/bin/kafka-consumer-groups.sh --bootstrap-server localhost:9092 --group kafka-ml-api-adapter --describe; sleep 5; done"

--- a/testPI2/util/scripts/restartMockServer.sh
+++ b/testPI2/util/scripts/restartMockServer.sh
@@ -18,18 +18,6 @@ echo
 echo "---------------------------------------------------------------------"
 echo " Creating MockServer Instance"
 echo "---------------------------------------------------------------------"
-echo "Ensure your ML-API-Adapter config points to the following end-points for callbacks:"
-echo "Add the following entries to: \"DFSP_URLS\":"
-echo "    ------------------------------------------------------"
-for FSP in "${FSPList[@]}"
-do
-  echo "    \"$FSP\": {"
-  echo "      \"transfers\": \"http://localhost:1080/transfers\","
-  echo "      \"error\": \"http://localhost:1080/transfers/error\""
-  echo "    }"
-  echo "    ------------------------------------------------------"
-done
-echo
 
 echo
 echo "Destroying MockServer ${MOCKSERVER_ID}"
@@ -47,18 +35,27 @@ echo
 
 echo
 echo "Configuring expectation for POST /transfers"
-docker run --rm --network host byrnedo/alpine-curl -X PUT "http://localhost:1080/expectation" -d '{ "httpRequest": { "method": "POST", "path": "/transfers" }, "httpResponse": { "statusCode": 200, "body": "{}" } }';
+docker run --rm --network host byrnedo/alpine-curl -X PUT "http://localhost:1080/expectation" -d '{ "httpRequest": { "method": "POST", "path": "/transfers(.*)" }, "times" : { "remainingTimes" : 0,	"unlimited" : true }, "timeToLive" : { "unlimited" : true }, "httpResponse": { "statusCode": 200, "body": "{}" } }';
 
 echo
 echo "Configuring expectation for PUT /transfers"
-docker run --rm --network host byrnedo/alpine-curl -X PUT "http://localhost:1080/expectation" -d '{ "httpRequest": { "method": "PUT", "path": "/transfers" }, "httpResponse": { "statusCode": 200, "body": "{}" } }';
+docker run --rm --network host byrnedo/alpine-curl -X PUT "http://localhost:1080/expectation" -d '{ "httpRequest": { "method": "PUT", "path": "/transfers(.*)" }, "times" : { "remainingTimes" : 0,	"unlimited" : true }, "timeToLive" : { "unlimited" : true }, "httpResponse": { "statusCode": 200, "body": "{}" } }';
 
+echo "---------------------------------------------------------------------"
+echo "Ensure your ML-API-Adapter config points to the following end-points for callbacks:"
+echo "Add the following entries to: \"DFSP_URLS\":"
+  echo "    ------------------------------------------------------"
+for FSP in "${FSPList[@]}"
+do
+  echo "    \"$FSP\": {"
+  echo "      \"transfers\": {"
+  echo "        \"post\": \"http://localhost:1080/transfers\","
+  echo "        \"put\": \"http://localhost:1080/transfers/{{transferId}}\","
+  echo "        \"error\": \"http://localhost:1080/transfers/{{transferId}}/error\""
+  echo "      }"
+  echo "    }"
+  echo "    ------------------------------------------------------"
+done
 echo
-echo "Configuring expectation for POST /transfers/error"
-docker run --rm --network host byrnedo/alpine-curl -X PUT "http://localhost:1080/expectation" -d '{ "httpRequest": { "method": "POST", "path": "/transfers/error" }, "httpResponse": { "statusCode": 200, "body": "{}" } }';
-
-echo
-echo "Configuring expectation for PUT /transfers/error"
-docker run --rm --network host byrnedo/alpine-curl -X PUT "http://localhost:1080/expectation" -d '{ "httpRequest": { "method": "PUT", "path": "/transfers/error" }, "httpResponse": { "statusCode": 200, "body": "{}" } }';
 
 echo "${MOCKSERVER_ID} ready to accept requests..."


### PR DESCRIPTION
Fixed helper scripts as per the meeting:
1. Updated expectations for Mock-Server to correctly work for all requests, and never expire
2. Updated monitor script for Johnny Park Kafka Container which has been updated with a new version of Kafka
3. Updated start scripts to correctly print the config end-points for each DFSP