### PR TITLE
Bugfix/426-448-Past Expiration and Timeout Notifications

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,5 +1,5 @@
 {
-  "PORT": 3000,
+  "PORT": 4000,
   "ADMIN_PORT": 3001,
   "HOSTNAME": "http://central-ledger",
   "ENABLE_TOKEN_AUTH": false,

--- a/src/handlers/positions/handler.js
+++ b/src/handlers/positions/handler.js
@@ -161,7 +161,7 @@ const positions = async (error, messages) => {
         throw new Error('Internal server error')
       } else { // transfer state check success
         const isIncrease = false
-        const reason = 'Aborted by Position Handler due to expiration'
+        const reason = 'Transfer aborted due to expiration'
         const transferStateChange = {
           transferId: transferInfo.transferId,
           transferStateId: TransferState.EXPIRED_RESERVED,

--- a/src/handlers/transfers/handler.js
+++ b/src/handlers/transfers/handler.js
@@ -115,7 +115,6 @@ const prepare = async (error, messages) => {
       if (!transferState || !transferState.enumeration) {
         // Transfer state not found send callback notification
         Logger.info('TransferService::prepare::dupcheck::existsMatching::transfer state not found send callback notification')
-
         message.value.content.payload = Utility.createPrepareErrorStatus(errorGenericCode, errorGenericDescription, message.value.content.payload.extensionList)
         await Utility.produceGeneralMessage(TransferEventType.NOTIFICATION, TransferEventAction.PREPARE, message.value, Utility.createState(Utility.ENUMS.STATE.FAILURE.status, errorGenericCode, errorGenericDescription))
         return true
@@ -202,8 +201,9 @@ const prepare = async (error, messages) => {
 
       // send the callback notification for validation error
       Logger.info('TransferService::prepare::validationFailed::send the callback notification for validation error')
-      message.value.content.payload = Utility.createPrepareErrorStatus(errorGenericCode, errorGenericDescription, message.value.content.payload.extensionList)
-      await Utility.produceGeneralMessage(TransferEventType.NOTIFICATION, TransferEventAction.PREPARE, message.value, Utility.createState(Utility.ENUMS.STATE.FAILURE.status, errorGenericCode, errorGenericDescription))
+      let errorDescription = `${errorGenericDescription}: ${reasons.toString()}`
+      message.value.content.payload = Utility.createPrepareErrorStatus(errorGenericCode, errorDescription, message.value.content.payload.extensionList)
+      await Utility.produceGeneralMessage(TransferEventType.NOTIFICATION, TransferEventAction.PREPARE, message.value, Utility.createState(Utility.ENUMS.STATE.FAILURE.status, errorGenericCode, errorDescription))
       return true
     }
   } catch (error) {

--- a/src/handlers/transfers/validator.js
+++ b/src/handlers/transfers/validator.js
@@ -107,7 +107,7 @@ const fulfilmentToCondition = (fulfilment) => {
   var preimage = base64url.toBuffer(fulfilment)
 
   if (preimage.length !== 32) {
-    throw new Error('Interledger preimages must be exactly 32 bytes.')
+    throw new Error('Interledger preimages must be exactly 32 bytes')
   }
 
   var calculatedConditionDigest = hashSha256.update(preimage).digest('base64')
@@ -126,7 +126,7 @@ const validateFulfilCondition = (fulfilment, condition) => {
 
 const validateConditionAndExpiration = async (payload) => {
   if (!payload.condition) {
-    reasons.push('condition is required for a conditional transfer')
+    reasons.push('Condition is required for a conditional transfer')
     return false
   }
   try {
@@ -138,11 +138,11 @@ const validateConditionAndExpiration = async (payload) => {
   }
   if (payload.expiration) {
     if (Date.parse(payload.expiration) < Date.parse(new Date().toDateString())) {
-      reasons.push(`expiration date: ${new Date(payload.expiration.toString()).toISOString()} has already expired.`)
+      reasons.push(`Expiration date ${new Date(payload.expiration.toString()).toISOString()} is already in the past`)
       return false
     }
   } else {
-    reasons.push('expiration: required for conditional transfer')
+    reasons.push('Expiration is required for conditional transfer')
     return false
   }
   return true

--- a/testPI2/unit/handlers/transfers/validator.test.js
+++ b/testPI2/unit/handlers/transfers/validator.test.js
@@ -78,17 +78,17 @@ Test('transfer validator', validatorTest => {
       payload.condition = null
       const {validationPassed, reasons} = await Validator.validateByName(payload)
       test.equal(validationPassed, false)
-      test.deepEqual(reasons, ['condition is required for a conditional transfer'])
+      test.deepEqual(reasons, ['Condition is required for a conditional transfer'])
       test.end()
     })
 
-    validateByNameTest.test('fail validation for invalid expiration date', async (test) => {
+    validateByNameTest.test('Fail validation for invalid expiration date', async (test) => {
       Participant.getByName.returns(P.resolve({}))
       CryptoConditions.validateCondition.returns(true)
       payload.expiration = '1971-11-24T08:38:08.699-04:00'
       const {validationPassed, reasons} = await Validator.validateByName(payload)
       test.equal(validationPassed, false)
-      test.deepEqual(reasons, ['expiration date: 1971-11-24T12:38:08.699Z has already expired.'])
+      test.deepEqual(reasons, ['Expiration date 1971-11-24T12:38:08.699Z is already in the past'])
       test.end()
     })
 
@@ -98,7 +98,7 @@ Test('transfer validator', validatorTest => {
       payload.expiration = null
       const {validationPassed, reasons} = await Validator.validateByName(payload)
       test.equal(validationPassed, false)
-      test.deepEqual(reasons, ['expiration: required for conditional transfer'])
+      test.deepEqual(reasons, ['Expiration is required for conditional transfer'])
       test.end()
     })
 

--- a/testPI2/util/scripts/restartDb.sh
+++ b/testPI2/util/scripts/restartDb.sh
@@ -30,7 +30,7 @@ docker run -p 3306:3306 -d --name ${DB_ID} -v ${DB_ID}data:/var/lib/mysql -e MYS
 sleep $DB_SLEEPTIME;
 
 is_db_up() {
-  docker exec -it mysql ${DB_ID} -uroot -e "select 1"
+  docker exec -it ${DB_ID} mysql -uroot -e "select 1"
 }
 
 echo "Waiting for DB to start"
@@ -39,6 +39,6 @@ until is_db_up; do
   sleep $SLEEP_FACTOR_IN_SECONDS
 done
 
-docker exec -it $DB_ID ${DB_ID} -uroot -e "ALTER USER '$DBUSER'@'%' IDENTIFIED WITH mysql_native_password BY '$DBPASS';"
+docker exec -it ${DB_ID} mysql -uroot -e "ALTER USER '$DBUSER'@'%' IDENTIFIED WITH mysql_native_password BY '$DBPASS';"
 
 echo "${DB_ID} ready to accept requests..."


### PR DESCRIPTION
Fixed 426 & 448 and adapted unit tests according to the provided description in:
- [x] [Story #426](https://github.com/mojaloop/project/issues/426)
- [x] [Story #448](https://github.com/mojaloop/project/issues/448)

Modified restartMockserver.sh script to await mockserver start before PUT expectations.
Changed default.json port for api to 4000 as 3000 is now used by ml-api-adapter.

Coverage summary report:
```
=============================== Coverage summary ===============================
Statements   : 68.46% ( 2192/3202 )
Branches     : 62.37% ( 474/760 )
Functions    : 52.04% ( 281/540 )
Lines        : 68.95% ( 2178/3159 )
================================================================================

1..769
# tests 769
# pass  769

# ok
```