### PR TITLE
Feature/461 Settlement Transfer

### DIFF
--- a/migrations/110450_ledgerAccountType.js
+++ b/migrations/110450_ledgerAccountType.js
@@ -24,41 +24,20 @@
 
 'use strict'
 
-const ledgerEntryTypes = [
-  {
-    'name': 'PRINCIPLE_VALUE',
-    'description': 'The principle amount to be settled between parties, derived on quotes between DFSPs'
-  },
-  {
-    'name': 'INTERCHANGE_FEE',
-    'description': 'Fees to be paid between DFSP'
-  },
-  {
-    'name': 'HUB_FEE',
-    'description': 'Fees to be paid from the DFSPs to the Hub Operator'
-  },
-  {
-    'name': 'SETTLEMENT_ACCOUNT',
-    'description': 'Used to correspond with SETTLEMENT_DEPOSIT or SETTLEMENT_WITHDRAWAL'
-  },
-  {
-    'name': 'SETTLEMENT_DEPOSIT',
-    'description': 'The amount deposited by a DFSP during the settlement process'
-  },
-  {
-    'name': 'SETTLEMENT_WITHDRAWAL',
-    'description': 'The amount being with withdrawn by a DFSP duriing the settlement process'
-  }
-]
-
-exports.seed = async function (knex) {
-  try {
-    return await knex('ledgerEntryType').insert(ledgerEntryTypes)
-  } catch (err) {
-    if (err.code === 'ER_DUP_ENTRY') return -1001
-    else {
-      console.log(`Uploading seeds for ledgerEntryType has failed with the following error: ${err}`)
-      return -1000
+exports.up = async (knex, Promise) => {
+  return await knex.schema.hasTable('ledgerAccountType').then(function(exists) {
+    if (!exists) {
+      return knex.schema.createTable('ledgerAccountType', (t) => {
+        t.increments('ledgerAccountTypeId').primary().notNullable()
+        t.string('name', 50).notNullable()
+        t.string('description', 512).defaultTo(null).nullable()
+        t.boolean('isActive').defaultTo(true).notNullable()
+        t.dateTime('createdDate').defaultTo(knex.fn.now()).notNullable()
+      })
     }
-  }
+  })
+}
+
+exports.down = function (knex, Promise) {
+  return knex.schema.dropTableIfExists('ledgerAccountType')
 }

--- a/migrations/110451_ledgerAccountType-indexes.js
+++ b/migrations/110451_ledgerAccountType-indexes.js
@@ -24,41 +24,14 @@
 
 'use strict'
 
-const ledgerEntryTypes = [
-  {
-    'name': 'PRINCIPLE_VALUE',
-    'description': 'The principle amount to be settled between parties, derived on quotes between DFSPs'
-  },
-  {
-    'name': 'INTERCHANGE_FEE',
-    'description': 'Fees to be paid between DFSP'
-  },
-  {
-    'name': 'HUB_FEE',
-    'description': 'Fees to be paid from the DFSPs to the Hub Operator'
-  },
-  {
-    'name': 'SETTLEMENT_ACCOUNT',
-    'description': 'Used to correspond with SETTLEMENT_DEPOSIT or SETTLEMENT_WITHDRAWAL'
-  },
-  {
-    'name': 'SETTLEMENT_DEPOSIT',
-    'description': 'The amount deposited by a DFSP during the settlement process'
-  },
-  {
-    'name': 'SETTLEMENT_WITHDRAWAL',
-    'description': 'The amount being with withdrawn by a DFSP duriing the settlement process'
-  }
-]
+exports.up = function (knex, Promise) {
+  return knex.schema.table('ledgerAccountType', (t) => {
+    t.unique('name')
+  })
+}
 
-exports.seed = async function (knex) {
-  try {
-    return await knex('ledgerEntryType').insert(ledgerEntryTypes)
-  } catch (err) {
-    if (err.code === 'ER_DUP_ENTRY') return -1001
-    else {
-      console.log(`Uploading seeds for ledgerEntryType has failed with the following error: ${err}`)
-      return -1000
-    }
-  }
+exports.down = function (knex, Promise) {
+  return knex.schema.table('ledgerAccountType', (t) => {
+    t.dropUnique('name')
+  })
 }

--- a/migrations/310100_participantCurrency.js
+++ b/migrations/310100_participantCurrency.js
@@ -33,6 +33,8 @@ exports.up = async (knex, Promise) => {
         t.foreign('participantId').references('participantId').inTable('participant')
         t.string('currencyId', 3).notNullable()
         t.foreign('currencyId').references('currencyId').inTable('currency')
+        t.integer('ledgerAccountTypeId').unsigned().notNullable()
+        t.foreign('ledgerAccountTypeId').references('ledgerAccountTypeId').inTable('ledgerAccountType')
         t.boolean('isActive').defaultTo(true).notNullable()
         t.dateTime('createdDate').defaultTo(knex.fn.now()).notNullable()
         t.string('createdBy', 128).notNullable()

--- a/migrations/310101_participantCurrency-indexes.js
+++ b/migrations/310101_participantCurrency-indexes.js
@@ -28,7 +28,7 @@ exports.up = function (knex, Promise) {
   return knex.schema.table('participantCurrency', (t) => {
     t.index('participantId')
     t.index('currencyId')
-    t.unique(['participantId', 'currencyId'])
+    t.unique(['participantId', 'currencyId', 'ledgerAccountTypeId'], 'participantcurrency_pcl_unique')
   })
 }
 
@@ -36,6 +36,6 @@ exports.down = function (knex, Promise) {
   return knex.schema.table('participantCurrency', (t) => {
     t.dropIndex('participantId')
     t.dropIndex('currencyId')
-    t.dropUnique(['participantId', 'currencyId'])
+    t.dropUnique(['participantId', 'currencyId', 'ledgerAccountTypeId'], 'participantcurrency_pcl_unique')
   })
 }

--- a/migrations/400600_settlementParticipantCurrency.js
+++ b/migrations/400600_settlementParticipantCurrency.js
@@ -36,6 +36,7 @@ exports.up = async (knex, Promise) => {
         t.decimal('netAmount', 18, 2).notNullable()
         t.dateTime('createdDate').defaultTo(knex.fn.now()).notNullable()
         t.bigInteger('currentStateChangeId').unsigned().nullable()
+        t.string('settlementTransferId', 36).nullable()
       })
     }
   })

--- a/migrations/400601_settlementParticipantCurrency-indexes.js
+++ b/migrations/400601_settlementParticipantCurrency-indexes.js
@@ -28,6 +28,7 @@ exports.up = function (knex, Promise) {
   return knex.schema.table('settlementParticipantCurrency', (t) => {
     t.index('settlementId')
     t.index('participantCurrencyId')
+    t.index('settlementTransferId')
   })
 }
 
@@ -35,5 +36,6 @@ exports.down = function (knex, Promise) {
   return knex.schema.table('settlementParticipantCurrency', (t) => {
     t.dropIndex('settlementId')
     t.dropIndex('participantCurrencyId')
+    t.dropIndex('settlementTransferId')
   })
 }

--- a/seeds/ledgerAccountType.js
+++ b/seeds/ledgerAccountType.js
@@ -24,40 +24,24 @@
 
 'use strict'
 
-const ledgerEntryTypes = [
+const ledgerAccountTypes = [
   {
-    'name': 'PRINCIPLE_VALUE',
-    'description': 'The principle amount to be settled between parties, derived on quotes between DFSPs'
+    'name': 'POSITION',
+    'description': 'Position account are used during regular transfers between DFSPs'
   },
   {
-    'name': 'INTERCHANGE_FEE',
-    'description': 'Fees to be paid between DFSP'
-  },
-  {
-    'name': 'HUB_FEE',
-    'description': 'Fees to be paid from the DFSPs to the Hub Operator'
-  },
-  {
-    'name': 'SETTLEMENT_ACCOUNT',
-    'description': 'Used to correspond with SETTLEMENT_DEPOSIT or SETTLEMENT_WITHDRAWAL'
-  },
-  {
-    'name': 'SETTLEMENT_DEPOSIT',
-    'description': 'The amount deposited by a DFSP during the settlement process'
-  },
-  {
-    'name': 'SETTLEMENT_WITHDRAWAL',
-    'description': 'The amount being with withdrawn by a DFSP duriing the settlement process'
+    'name': 'SETTLEMENT',
+    'description': 'Settlement account are used during the settlement process'
   }
 ]
 
 exports.seed = async function (knex) {
   try {
-    return await knex('ledgerEntryType').insert(ledgerEntryTypes)
+    return await knex('ledgerAccountType').insert(ledgerAccountTypes)
   } catch (err) {
     if (err.code === 'ER_DUP_ENTRY') return -1001
     else {
-      console.log(`Uploading seeds for ledgerEntryType has failed with the following error: ${err}`)
+      console.log(`Uploading seeds for ledgerAccountType has failed with the following error: ${err}`)
       return -1000
     }
   }

--- a/seeds/ledgerAccountType.js
+++ b/seeds/ledgerAccountType.js
@@ -27,11 +27,15 @@
 const ledgerAccountTypes = [
   {
     'name': 'POSITION',
-    'description': 'Position account are used during regular transfers between DFSPs'
+    'description': 'Typical accounts from which a DFSP provisions  transfers '
   },
   {
     'name': 'SETTLEMENT',
-    'description': 'Settlement account are used during the settlement process'
+    'description': 'Reflects the individual DFSP Settlement Accounts as held at the Settlement Bank'
+  },
+  {
+    'name': 'HUB_SETTLEMENT',
+    'description': 'A single account for each currency with which the hub operates. The account is "held" by the Participant representing the hub in the switch'
   }
 ]
 

--- a/seeds/ledgerEntryType.js
+++ b/seeds/ledgerEntryType.js
@@ -52,6 +52,10 @@ const ledgerEntryTypes = [
   {
     'name': 'SETTLEMENT_NET_SENDER',
     'description': 'Participant is settlement net sender (///+/- reducing position, therefore increasing available position against NDC)'
+  },
+  {
+    'name': 'SETTLEMENT_NET_ZERO',
+    'description': 'Participant is settlement net sender (///+/- reducing position, therefore increasing available position against NDC)'
   }
 ]
 

--- a/seeds/ledgerEntryType.js
+++ b/seeds/ledgerEntryType.js
@@ -56,6 +56,14 @@ const ledgerEntryTypes = [
   {
     'name': 'SETTLEMENT_NET_ZERO',
     'description': 'Participant is settlement net sender (///+/- reducing position, therefore increasing available position against NDC)'
+  },
+  {
+    'name': 'SETTLEMENT_ACCOUNT_DEPOSIT',
+    'description': ''
+  },
+  {
+    'name': 'SETTLEMENT_ACCOUNT_WITHDRAWAL',
+    'description': ''
   }
 ]
 

--- a/seeds/ledgerEntryType.js
+++ b/seeds/ledgerEntryType.js
@@ -27,27 +27,31 @@
 const ledgerEntryTypes = [
   {
     'name': 'PRINCIPLE_VALUE',
-    'description': 'The principle amount to be settled between parties, derived on quotes between DFSPs'
+    'description': 'The principle amount to be settled between parties, derived on quotes between DFSPs (+/-///)'
   },
   {
     'name': 'INTERCHANGE_FEE',
-    'description': 'Fees to be paid between DFSP'
+    'description': 'Fees to be paid between DFSP (±/±///)'
   },
   {
     'name': 'HUB_FEE',
-    'description': 'Fees to be paid from the DFSPs to the Hub Operator'
+    'description': 'Fees to be paid from the DFSPs to the Hub Operator (-/-/+//)'
   },
   {
-    'name': 'SETTLEMENT_ACCOUNT',
-    'description': 'Used to correspond with SETTLEMENT_DEPOSIT or SETTLEMENT_WITHDRAWAL'
+    'name': 'POSITION_DEPOSIT',
+    'description': 'Used when increasing Net Debit Cap (///+/- more funds available)'
   },
   {
-    'name': 'SETTLEMENT_DEPOSIT',
-    'description': 'The amount deposited by a DFSP during the settlement process'
+    'name': 'POSITION_WITHDRAWAL',
+    'description': 'Used when decreasing Net Debit Cap (///-/+ less funds available - not to exceed NDC)'
   },
   {
-    'name': 'SETTLEMENT_WITHDRAWAL',
-    'description': 'The amount being with withdrawn by a DFSP duriing the settlement process'
+    'name': 'SETTLEMENT_NET_RECIPIENT',
+    'description': 'Participant is settlement net recipient (///-/+ negative position will be increased to show I have less position to operate with as it returns to zero)'
+  },
+  {
+    'name': 'SETTLEMENT_NET_SENDER',
+    'description': 'Participant is settlement net sender (///+/- reducing position, therefore increasing available position against NDC)'
   }
 ]
 

--- a/seeds/transferParticipantRoleType.js
+++ b/seeds/transferParticipantRoleType.js
@@ -44,10 +44,6 @@ const transferParticipantRoleTypes = [
   {
     'name': 'DFSP_POSITION_ACCOUNT',
     'description': 'Indicates the position account'
-  },
-  {
-    'name': 'DFSP_POSITION_ACCOUNT',
-    'description': 'Indicates the position account'
   }
 ]
 

--- a/seeds/transferParticipantRoleType.js
+++ b/seeds/transferParticipantRoleType.js
@@ -38,8 +38,12 @@ const transferParticipantRoleTypes = [
     'description': 'The participant is representing the Hub Operator'
   },
   {
-    'name': 'SETTLEMENT_TRANSFER',
-    'description': 'Service participant used for settlement transfers'
+    'name': 'DFSP_SETTLEMENT_ACCOUNT',
+    'description': 'Indicates the settlement account'
+  },
+  {
+    'name': 'DFSP_POSITION_ACCOUNT',
+    'description': 'Indicates the position account'
   }
 ]
 

--- a/seeds/transferParticipantRoleType.js
+++ b/seeds/transferParticipantRoleType.js
@@ -44,6 +44,10 @@ const transferParticipantRoleTypes = [
   {
     'name': 'DFSP_POSITION_ACCOUNT',
     'description': 'Indicates the position account'
+  },
+  {
+    'name': 'DFSP_POSITION_ACCOUNT',
+    'description': 'Indicates the position account'
   }
 ]
 

--- a/seeds/transferParticipantRoleType.js
+++ b/seeds/transferParticipantRoleType.js
@@ -36,6 +36,10 @@ const transferParticipantRoleTypes = [
   {
     'name': 'HUB',
     'description': 'The participant is representing the Hub Operator'
+  },
+  {
+    'name': 'SETTLEMENT_TRANSFER',
+    'description': 'Service participant used for settlement transfers'
   }
 ]
 

--- a/src/admin/participants/handler.js
+++ b/src/admin/participants/handler.js
@@ -45,9 +45,10 @@ const entityItem = ({ name, createdDate, isActive, currencyList }) => {
   }
 }
 
-const currencyEntityItem = ({ currencyId, isActive }) => {
+const currencyEntityItem = ({ currencyId, isActive, ledgerAccountTypeId }) => {
   return {
     currency: currencyId,
+    ledgerAccountTypeId,
     isActive
   }
 }
@@ -81,8 +82,10 @@ const create = async function (request, h) {
       const participantId = await Participant.create(request.payload)
       participant = await Participant.getById(participantId)
     }
-    const participantCurrencyId = await Participant.createParticipantCurrency(participant.participantId, request.payload.currency)
-    participant.currencyList = [await Participant.getParticipantCurrencyById(participantCurrencyId)]
+    let ledgerAccountTypeEnum = await request.server.methods.enums('ledgerAccountType')
+    const participantCurrencyId1 = await Participant.createParticipantCurrency(participant.participantId, request.payload.currency, ledgerAccountTypeEnum.POSITION)
+    const participantCurrencyId2 = await Participant.createParticipantCurrency(participant.participantId, request.payload.currency, ledgerAccountTypeEnum.SETTLEMENT)
+    participant.currencyList = [await Participant.getParticipantCurrencyById(participantCurrencyId1), await Participant.getParticipantCurrencyById(participantCurrencyId2)]
     return h.response(entityItem(participant)).code(201)
   } catch (err) {
     throw Boom.badRequest(err.message)

--- a/src/admin/root/routes.js
+++ b/src/admin/root/routes.js
@@ -19,5 +19,14 @@ module.exports = [
       return h.response({ status: 'OK' }).code(200)
     },
     options: RouteConfig.config(tags, 'Status of ledger admin api')
+  },
+  {
+    method: 'GET',
+    path: '/enums',
+    handler: async function (request, h) {
+      let enums = await request.server.methods.enums('all')
+      return h.response(enums).code(200)
+    },
+    options: RouteConfig.config(tags, 'List available enumerations')
   }
 ]

--- a/src/domain/participant/index.js
+++ b/src/domain/participant/index.js
@@ -98,9 +98,9 @@ const update = async (name, payload) => {
   }
 }
 
-const createParticipantCurrency = async (participantId, currencyId) => {
+const createParticipantCurrency = async (participantId, currencyId, ledgerAccountTypeId) => {
   try {
-    const participantCurrency = await ParticipantCurrencyModel.create(participantId, currencyId)
+    const participantCurrency = await ParticipantCurrencyModel.create(participantId, currencyId, ledgerAccountTypeId)
     return participantCurrency
   } catch (err) {
     throw err

--- a/src/domain/participant/index.js
+++ b/src/domain/participant/index.js
@@ -36,6 +36,7 @@ const ParticipantLimitModel = require('../../models/participant/participantLimit
 const ParticipantFacade = require('../../models/participant/facade')
 const PositionFacade = require('../../models/position/facade')
 const Config = require('../../lib/config')
+const Enum = require('../../lib/enum')
 
 const create = async (payload) => {
   try {
@@ -52,7 +53,7 @@ const getAll = async () => {
     // TODO: refactor the query to use the facade layer and join query for both tables
     let all = await ParticipantModel.getAll()
     await Promise.all(all.map(async (participant) => {
-      participant.currencyList = await ParticipantCurrencyModel.getByParticipantId(participant.participantId)
+      participant.currencyList = await ParticipantCurrencyModel.getByParticipantId(participant.participantId, Enum.LedgerAccountType.POSITION)
     }))
     return all
   } catch (err) {
@@ -64,7 +65,7 @@ const getById = async (id) => {
   // TODO: refactor the query to use the facade layer and join query for both tables
   let participant = await ParticipantModel.getById(id)
   if (participant) {
-    participant.currencyList = await ParticipantCurrencyModel.getByParticipantId(participant.participantId)
+    participant.currencyList = await ParticipantCurrencyModel.getByParticipantId(participant.participantId, Enum.LedgerAccountType.POSITION)
   }
   return participant
 }
@@ -73,7 +74,7 @@ const getByName = async (name) => {
   // TODO: refactor the query to use the facade layer and join query for both tables
   let participant = await ParticipantModel.getByName(name)
   if (participant) {
-    participant.currencyList = await ParticipantCurrencyModel.getByParticipantId(participant.participantId)
+    participant.currencyList = await ParticipantCurrencyModel.getByParticipantId(participant.participantId, Enum.LedgerAccountType.POSITION)
   }
   return participant
 }
@@ -251,7 +252,7 @@ const destroyPariticpantEndpointByName = async (name) => {
 
 const addLimitAndInitialPosition = async (participantName, limitAndInitialPositionObj) => {
   try {
-    const participant = await ParticipantFacade.getByNameAndCurrency(participantName, limitAndInitialPositionObj.currency)
+    const participant = await ParticipantFacade.getByNameAndCurrency(participantName, limitAndInitialPositionObj.currency, Enum.LedgerAccountType.POSITION)
     participantExists(participant)
     const existingLimit = await ParticipantLimitModel.getByParticipantCurrencyId(participant.participantCurrencyId)
     const existingPosition = await ParticipantPositionModel.getByParticipantCurrencyId(participant.participantCurrencyId)
@@ -322,7 +323,7 @@ const getPositionChangeByParticipantPositionId = async (participantPositionId) =
 
 const destroyParticipantPositionByNameAndCurrency = async (name, currencyId) => {
   try {
-    const participant = await ParticipantFacade.getByNameAndCurrency(name, currencyId)
+    const participant = await ParticipantFacade.getByNameAndCurrency(name, currencyId, Enum.LedgerAccountType.POSITION)
     participantExists(participant)
     return ParticipantPositionModel.destroyByParticipantCurrencyId(participant.participantCurrencyId)
   } catch (err) {
@@ -345,7 +346,7 @@ const destroyParticipantPositionByNameAndCurrency = async (name, currencyId) => 
 
 const destroyParticipantLimitByNameAndCurrency = async (name, currencyId) => {
   try {
-    const participant = await ParticipantFacade.getByNameAndCurrency(name, currencyId)
+    const participant = await ParticipantFacade.getByNameAndCurrency(name, currencyId, Enum.LedgerAccountType.POSITION)
     participantExists(participant)
     return ParticipantLimitModel.destroyByParticipantCurrencyId(participant.participantCurrencyId)
   } catch (err) {
@@ -374,13 +375,13 @@ const getLimits = async (name, { currency = null, type = null }) => {
   try {
     let participant
     if (currency != null) {
-      participant = await ParticipantFacade.getByNameAndCurrency(name, currency)
+      participant = await ParticipantFacade.getByNameAndCurrency(name, currency, Enum.LedgerAccountType.POSITION)
       participantExists(participant)
       return ParticipantFacade.getParticipantLimitsByCurrencyId(participant.participantCurrencyId, type)
     } else {
       participant = await ParticipantModel.getByName(name)
       participantExists(participant)
-      return ParticipantFacade.getParticipantLimitsByParticipantId(participant.participantId, type)
+      return ParticipantFacade.getParticipantLimitsByParticipantId(participant.participantId, type, Enum.LedgerAccountType.POSITION)
     }
   } catch (err) {
     throw err
@@ -411,7 +412,7 @@ const getLimits = async (name, { currency = null, type = null }) => {
 
 const adjustLimits = async (name, payload) => {
   try {
-    const participant = await ParticipantFacade.getByNameAndCurrency(name, payload.currency)
+    const participant = await ParticipantFacade.getByNameAndCurrency(name, payload.currency, Enum.LedgerAccountType.POSITION)
     participantExists(participant)
     return ParticipantFacade.adjustLimits(participant.participantCurrencyId, payload.limit)
   } catch (err) {
@@ -465,9 +466,9 @@ const adjustLimits = async (name, payload) => {
 const getPositions = async (name, query) => {
   try {
     if (query.currency) {
-      const participant = await ParticipantFacade.getByNameAndCurrency(name, query.currency)
+      const participant = await ParticipantFacade.getByNameAndCurrency(name, query.currency, Enum.LedgerAccountType.POSITION)
       participantExists(participant)
-      const result = await PositionFacade.getByNameAndCurrency(name, query.currency)
+      const result = await PositionFacade.getByNameAndCurrency(name, query.currency, Enum.LedgerAccountType.POSITION)
       let position = {}
       if (Array.isArray(result) && result.length > 0) {
         position = {
@@ -480,7 +481,7 @@ const getPositions = async (name, query) => {
     } else {
       const participant = await ParticipantModel.getByName(name)
       participantExists(participant)
-      const result = await await PositionFacade.getByNameAndCurrency(name)
+      const result = await await PositionFacade.getByNameAndCurrency(name, null, Enum.LedgerAccountType.POSITION)
       let positions = []
       if (Array.isArray(result) && result.length > 0) {
         result.forEach(item => {

--- a/src/lib/enum.js
+++ b/src/lib/enum.js
@@ -1,14 +1,122 @@
 'use strict'
 
+const Db = require('../db')
+
+const endpointType = async function () {
+  try {
+    let endpointType = {}
+    for (let record of await Db.endpointType.find({})) {
+      endpointType[`${record.name}`] = record.endpointTypeId
+    }
+    return endpointType
+  } catch (err) {
+    throw err
+  }
+}
+const ledgerAccountType = async function () {
+  try {
+    let ledgerAccountType = {}
+    for (let record of await Db.ledgerAccountType.find({})) {
+      ledgerAccountType[`${record.name}`] = record.ledgerAccountTypeId
+    }
+    return ledgerAccountType
+  } catch (err) {
+    throw err
+  }
+}
+const ledgerEntryType = async function () {
+  try {
+    let ledgerEntryType = {}
+    for (let record of await Db.ledgerEntryType.find({})) {
+      ledgerEntryType[`${record.name}`] = record.ledgerEntryTypeId
+    }
+    return ledgerEntryType
+  } catch (err) {
+    throw err
+  }
+}
+const participantLimitType = async function () {
+  try {
+    let participantLimitType = {}
+    for (let record of await Db.participantLimitType.find({})) {
+      participantLimitType[`${record.name}`] = record.participantLimitTypeId
+    }
+    return participantLimitType
+  } catch (err) {
+    throw err
+  }
+}
+const transferParticipantRoleType = async function () {
+  try {
+    let transferParticipantRoleType = {}
+    for (let record of await Db.transferParticipantRoleType.find({})) {
+      transferParticipantRoleType[`${record.name}`] = record.transferParticipantRoleTypeId
+    }
+    return transferParticipantRoleType
+  } catch (err) {
+    throw err
+  }
+}
+const transferState = async function () {
+  try {
+    let transferState = {}
+    for (let record of await Db.transferState.find({})) {
+      transferState[`${record.transferStateId}`] = record.transferStateId
+    }
+    return transferState
+  } catch (err) {
+    throw err
+  }
+}
+const transferStateEnum = async function () {
+  try {
+    let transferState = {}
+    for (let record of await Db.transferState.find({})) {
+      transferState[`${record.transferStateId}`] = record.enumeration
+    }
+    return transferState
+  } catch (err) {
+    throw err
+  }
+}
+const all = async function () {
+  try {
+    return {
+      endpointType: await endpointType(),
+      ledgerAccountType: await ledgerAccountType(),
+      ledgerEntryType: await ledgerEntryType(),
+      participantLimitType: await participantLimitType(),
+      transferParticipantRoleType: await transferParticipantRoleType(),
+      transferState: await transferState(),
+      transferStateEnum: await transferStateEnum()
+    }
+  } catch (err) {
+    throw err
+  }
+}
+
+// TODO: To be replaced throughout code with the above
 const EnpointType = {
   FSIOP_CALLBACK_URL: 1,
   ALARM_NOTIFICATION_URL: 2,
   ALARM_NOTIFICATION_TOPIC: 3
 }
+const LedgerAccountType = {
+  POSITION: 1,
+  SETTLEMENT: 2,
+  HUB_SETTLEMENT: 3
+}
 const LedgerEntryType = {
   PRINCIPLE_VALUE: 1,
   INTERCHANGE_FEE: 2,
-  HUB_FEE: 3
+  HUB_FEE: 3,
+  POSITION_DEPOSIT: 4,
+  POSITION_WITHDRAWAL: 5,
+  SETTLEMENT_NET_RECIPIENT: 6,
+  SETTLEMENT_NET_SENDER: 7,
+  SETTLEMENT_NET_ZERO: 8,
+  SETTLEMENT_ACCOUNT_DEPOSIT: 9,
+  SETTLEMENT_ACCOUNT_WITHDRAWAL: 10
 }
 const ParticipantLimitType = {
   NET_DEBIT_CAP: 1
@@ -16,21 +124,22 @@ const ParticipantLimitType = {
 const TransferParticipantRoleType = {
   PAYER_DFSP: 1,
   PAYEE_DFSP: 2,
-  HUB: 3
+  HUB: 3,
+  DFSP_SETTLEMENT_ACCOUNT: 4,
+  DFSP_POSITION_ACCOUNT: 5
 }
 const TransferState = {
-  RECEIVED_PREPARE: 'RECEIVED_PREPARE',
-  RESERVED: 'RESERVED',
-  RECEIVED: 'RECEIVED',
-  RECEIVED_FULFIL: 'RECEIVED_FULFIL',
-  COMMITTED: 'COMMITTED',
-  FAILED: 'FAILED',
-  RESERVED_TIMEOUT: 'RESERVED_TIMEOUT',
-  REJECTED: 'REJECTED',
   ABORTED: 'ABORTED',
-  INVALID: 'INVALID',
+  COMMITTED: 'COMMITTED',
   EXPIRED_PREPARED: 'EXPIRED_PREPARED',
-  EXPIRED_RESERVED: 'EXPIRED_RESERVED'
+  EXPIRED_RESERVED: 'EXPIRED_RESERVED',
+  FAILED: 'FAILED',
+  INVALID: 'INVALID',
+  RECEIVED_FULFIL: 'RECEIVED_FULFIL',
+  RECEIVED_PREPARE: 'RECEIVED_PREPARE',
+  REJECTED: 'REJECTED',
+  RESERVED: 'RESERVED',
+  RESERVED_TIMEOUT: 'RESERVED_TIMEOUT'
 }
 
 // Code specific (non-DB) enumerations sorted alphabetically
@@ -57,9 +166,6 @@ const transferEventAction = {
 const rejectionType = {
   EXPIRED: 'expired',
   CANCELLED: 'cancelled'
-}
-const limitType = {
-  NET_DEBIT_CAP: 1
 }
 const transferEventStatus = {
   SUCCESS: 'success',
@@ -156,7 +262,17 @@ const topicMap = {
 }
 
 module.exports = {
+  endpointType,
+  ledgerAccountType,
+  ledgerEntryType,
+  participantLimitType,
+  transferParticipantRoleType,
+  transferState,
+  transferStateEnum,
+  all,
+
   EnpointType,
+  LedgerAccountType,
   LedgerEntryType,
   ParticipantLimitType,
   TransferParticipantRoleType,
@@ -165,7 +281,6 @@ module.exports = {
   transferEventType,
   transferEventAction,
   rejectionType,
-  limitType,
   transferEventStatus,
   headers,
   topicMap

--- a/src/models/participant/facade.js
+++ b/src/models/participant/facade.js
@@ -30,7 +30,7 @@
 
 const Db = require('../../db')
 
-const getByNameAndCurrency = async (name, currencyId) => {
+const getByNameAndCurrency = async (name, currencyId, ledgerAccountTypeId) => {
   try {
     return await Db.participant.query(async (builder) => {
       return builder
@@ -38,6 +38,7 @@ const getByNameAndCurrency = async (name, currencyId) => {
         .andWhere({ 'participant.isActive': true })
         .andWhere({ 'pc.currencyId': currencyId })
         .andWhere({ 'pc.isActive': true })
+        .andWhere({ 'pc.ledgerAccountTypeId': ledgerAccountTypeId })
         .innerJoin('participantCurrency AS pc', 'pc.participantId', 'participant.participantId')
         .select(
           'participant.*',
@@ -51,13 +52,14 @@ const getByNameAndCurrency = async (name, currencyId) => {
   }
 }
 
-const getParticipantLimitByParticipantIdAndCurrencyId = async (participantId, currencyId) => {
+const getParticipantLimitByParticipantIdAndCurrencyId = async (participantId, currencyId, ledgerAccountTypeId) => {
   try {
     return await Db.participant.query(async (builder) => {
       return await builder
         .where({
           'participant.participantId': participantId,
-          'pc.currencyId': currencyId
+          'pc.currencyId': currencyId,
+          'pc.ledgerAccountTypeId': ledgerAccountTypeId
         })
         .innerJoin('participantCurrency AS pc', 'pc.participantId', 'participant.participantId')
         .innerJoin('participantLimit AS pl', 'pl.participantCurrencyId', 'pl.participantCurrencyId')
@@ -187,13 +189,14 @@ const addEndpoint = async (participantId, endpoint) => {
   }
 }
 
-const getParticipantLimitByParticipantCurrencyLimit = async (participantId, currencyId, participantLimitTypeId) => {
+const getParticipantLimitByParticipantCurrencyLimit = async (participantId, currencyId, ledgerAccountTypeId, participantLimitTypeId) => {
   try {
     return await Db.participant.query(async (builder) => {
       return await builder
         .where({
           'participant.participantId': participantId,
           'pc.currencyId': currencyId,
+          'pc.ledgerAccountTypeId': ledgerAccountTypeId,
           'pl.participantLimitTypeId': participantLimitTypeId,
           'participant.isActive': 1,
           'pc.IsActive': 1,
@@ -213,13 +216,14 @@ const getParticipantLimitByParticipantCurrencyLimit = async (participantId, curr
   }
 }
 
-const getParticipantPositionByParticipantIdAndCurrencyId = async (participantId, currencyId) => {
+const getParticipantPositionByParticipantIdAndCurrencyId = async (participantId, currencyId, ledgerAccountTypeId) => {
   try {
     return await Db.participant.query(async (builder) => {
       return await builder
         .where({
           'participant.participantId': participantId,
-          'pc.currencyId': currencyId
+          'pc.currencyId': currencyId,
+          'pc.ledgerAccountTypeId': ledgerAccountTypeId
         })
         .innerJoin('participantCurrency AS pc', 'pc.participantId', 'participant.participantId')
         .innerJoin('participantPosition AS pp', 'pp.participantCurrencyId', 'pc.participantCurrencyId')
@@ -407,13 +411,14 @@ const getParticipantLimitsByCurrencyId = async (participantCurrencyId, type) => 
  * @returns {array} - Returns an array containing the list of all active limits for the participant and type if successful, or throws an error if failed
  */
 
-const getParticipantLimitsByParticipantId = async (participantId, type) => {
+const getParticipantLimitsByParticipantId = async (participantId, type, ledgerAccountTypeId) => {
   try {
     return Db.participantLimit.query(builder => {
       return builder.innerJoin('participantLimitType AS lt', 'participantLimit.participantLimitTypeId', 'lt.participantLimitTypeId')
         .innerJoin('participantCurrency AS pc', 'participantLimit.participantCurrencyId', 'pc.participantCurrencyId')
         .where({
           'pc.participantId': participantId,
+          'pc.ledgerAccountTypeId': ledgerAccountTypeId,
           'pc.isActive': 1,
           'lt.isActive': 1,
           'participantLimit.isActive': 1

--- a/src/models/participant/participantCurrency.js
+++ b/src/models/participant/participantCurrency.js
@@ -26,11 +26,12 @@
 
 const Db = require('../../db')
 
-exports.create = async (participantId, currencyId) => {
+exports.create = async (participantId, currencyId, ledgerAccountTypeId) => {
   try {
     let result = await Db.participantCurrency.insert({
       participantId,
       currencyId,
+      ledgerAccountTypeId,
       createdBy: 'unknown'
     })
     return result

--- a/src/models/participant/participantCurrency.js
+++ b/src/models/participant/participantCurrency.js
@@ -48,9 +48,9 @@ exports.getById = async (id) => {
   }
 }
 
-exports.getByParticipantId = async (id) => {
+exports.getByParticipantId = async (id, ledgerAccountTypeId = null) => {
   try {
-    return await Db.participantCurrency.find({participantId: id}, { order: 'currencyId asc' })
+    return await Db.participantCurrency.find({participantId: id, ledgerAccountTypeId}, { order: 'currencyId asc' })
   } catch (err) {
     throw new Error(err.message)
   }

--- a/src/models/position/facade.js
+++ b/src/models/position/facade.js
@@ -100,7 +100,7 @@ const prepareChangeParticipantPositionTransaction = async (transferList) => {
         await knex('participantPosition').transacting(trx).where({ participantPositionId: initialParticipantPosition.participantPositionId }).update(initialParticipantPosition)
         // Get the actual position limit and calculate the available position for the transfers to use in this batch
         // Note: see optimisation decision notes to understand the justification for the algorithm
-        const participantLimit = await participantFacade.getParticipantLimitByParticipantCurrencyLimit(participantCurrency.participantId, participantCurrency.currencyId, Enum.limitType.NET_DEBIT_CAP)
+        const participantLimit = await participantFacade.getParticipantLimitByParticipantCurrencyLimit(participantCurrency.participantId, participantCurrency.currencyId, Enum.ParticipantLimitType.NET_DEBIT_CAP)
         let availablePosition = participantLimit.value - effectivePosition
         /* Validate entire batch if availablePosition >= sumTransfersInBatch - the impact is that applying per transfer rules would require to be handled differently
            since further rules are expected we do not do this at this point

--- a/src/models/position/facade.js
+++ b/src/models/position/facade.js
@@ -40,7 +40,7 @@ const prepareChangeParticipantPositionTransaction = async (transferList) => {
     const knex = await Db.getKnex()
     const participantName = transferList[0].value.content.payload.payerFsp
     const currencyId = transferList[0].value.content.payload.amount.currency
-    const participantCurrency = await participantFacade.getByNameAndCurrency(participantName, currencyId)
+    const participantCurrency = await participantFacade.getByNameAndCurrency(participantName, currencyId, Enum.LedgerAccountType.POSITION)
     let processedTransfers = {} // The list of processed transfers - so that we can store the additional information around the decision. Most importantly the "running" position
     let reservedTransfers = []
     let abortedTransfers = []
@@ -100,7 +100,7 @@ const prepareChangeParticipantPositionTransaction = async (transferList) => {
         await knex('participantPosition').transacting(trx).where({ participantPositionId: initialParticipantPosition.participantPositionId }).update(initialParticipantPosition)
         // Get the actual position limit and calculate the available position for the transfers to use in this batch
         // Note: see optimisation decision notes to understand the justification for the algorithm
-        const participantLimit = await participantFacade.getParticipantLimitByParticipantCurrencyLimit(participantCurrency.participantId, participantCurrency.currencyId, Enum.ParticipantLimitType.NET_DEBIT_CAP)
+        const participantLimit = await participantFacade.getParticipantLimitByParticipantCurrencyLimit(participantCurrency.participantId, participantCurrency.currencyId, Enum.LedgerAccountType.POSITION, Enum.ParticipantLimitType.NET_DEBIT_CAP)
         let availablePosition = participantLimit.value - effectivePosition
         /* Validate entire batch if availablePosition >= sumTransfersInBatch - the impact is that applying per transfer rules would require to be handled differently
            since further rules are expected we do not do this at this point
@@ -235,7 +235,7 @@ const changeParticipantPositionTransaction = async (participantCurrencyId, isInc
  * @returns {array} - Returns an array containing the details of active position(s) for the participant if successful, or throws an error if failed
  */
 
-const getByNameAndCurrency = async (name, currencyId = null) => {
+const getByNameAndCurrency = async (name, currencyId = null, ledgerAccountTypeId) => {
   try {
     return Db.participantPosition.query(builder => {
       return builder.innerJoin('participantCurrency AS pc', 'participantPosition.participantCurrencyId', 'pc.participantCurrencyId')
@@ -243,7 +243,8 @@ const getByNameAndCurrency = async (name, currencyId = null) => {
         .where({
           'p.name': name,
           'p.isActive': 1,
-          'pc.isActive': 1
+          'pc.isActive': 1,
+          'pc.ledgerAccountTypeId': ledgerAccountTypeId
         })
         .where(q => {
           if (currencyId != null) {

--- a/src/models/transfer/facade.js
+++ b/src/models/transfer/facade.js
@@ -253,7 +253,7 @@ const saveTransferPrepared = async (payload, stateReason = null, hasPassedValida
     const names = [payload.payeeFsp, payload.payerFsp]
 
     for (let name of names) {
-      const participant = await ParticipantFacade.getByNameAndCurrency(name, payload.amount.currency)
+      const participant = await ParticipantFacade.getByNameAndCurrency(name, payload.amount.currency, Enum.LedgerAccountType.POSITION)
       participants.push(participant)
     }
 

--- a/src/shared/setup.js
+++ b/src/shared/setup.js
@@ -61,7 +61,7 @@ const createServer = (port, modules) => {
       options: {
         cache: {
           cache: 'memCache',
-          expiresIn: 5 * 1000,
+          expiresIn: 5 * 60 * 1000,
           generateTimeout: 30 * 1000
         }
       }

--- a/src/shared/setup.js
+++ b/src/shared/setup.js
@@ -16,11 +16,14 @@ const Logger = require('@mojaloop/central-services-shared').Logger
 const Boom = require('boom')
 const RegisterHandlers = require('../handlers/register')
 const KafkaCron = require('../handlers/lib/kafka').Cron
+const Enums = require('../lib/enum')
 
 const migrate = (runMigrations) => {
   return runMigrations ? Migrator.migrate() : P.resolve()
 }
-
+const getEnums = (id) => {
+  return Enums[id]()
+}
 const connectDatabase = async () => await Db.connect(Config.DATABASE_URI)
 
 /**
@@ -36,12 +39,30 @@ const createServer = (port, modules) => {
   return (async () => {
     const server = await new Hapi.Server({
       port,
+      cache: [
+        {
+          name: 'memCache',
+          engine: require('catbox-memory'),
+          partition: 'cache'
+        }
+      ],
       routes: {
         validate: {
           options: ErrorHandling.validateRoutes(),
           failAction: async (request, h, err) => {
             throw Boom.boomify(err)
           }
+        }
+      }
+    })
+    server.method({
+      name: 'enums',
+      method: getEnums,
+      options: {
+        cache: {
+          cache: 'memCache',
+          expiresIn: 5 * 1000,
+          generateTimeout: 30 * 1000
         }
       }
     })

--- a/testPI2/integration/helpers/participant.js
+++ b/testPI2/integration/helpers/participant.js
@@ -30,6 +30,7 @@
 const Model = require('../../../src/domain/participant')
 const ParticipantCurrencyModel = require('../../../src/models/participant/participantCurrency')
 const time = require('../../../src/lib/time')
+const Enum = require('../../../src/lib/enum')
 
 const testParticipant = {
   name: 'fsp',
@@ -47,11 +48,13 @@ exports.prepareData = async (name, currencyId = 'USD') => {
         name: (name || testParticipant.name) + time.msToday()
       }
     ))
-    const participantCurrencyId = await ParticipantCurrencyModel.create(participantId, currencyId)
+    const participantCurrencyId = await ParticipantCurrencyModel.create(participantId, currencyId, Enum.LedgerAccountType.POSITION)
+    const participantCurrencyId2 = await ParticipantCurrencyModel.create(participantId, currencyId, Enum.LedgerAccountType.SETTLEMENT)
     const participant = await Model.getById(participantId)
     return {
       participant,
-      participantCurrencyId
+      participantCurrencyId,
+      participantCurrencyId2
     }
   } catch (err) {
     throw new Error(err.message)

--- a/testPI2/unit/domain/participant/index.test.js
+++ b/testPI2/unit/domain/participant/index.test.js
@@ -180,7 +180,7 @@ Test('Participant service', async (participantTest) => {
         currencyId: participant.currency,
         isActive: 1
       })
-      ParticipantCurrencyModel.getByParticipantId.withArgs(participant.participantId).returns(participant.currency)
+      ParticipantCurrencyModel.getByParticipantId.withArgs(participant.participantId, 1).returns(participant.currency)
       ParticipantModel.destroyByName.withArgs(participant.name).returns(Promise.resolve(true))
       ParticipantCurrencyModel.destroyByParticipantId.withArgs(participant.participantId).returns(Promise.resolve(true))
       Db.participant.destroy.withArgs({ name: participant.name }).returns(Promise.resolve(true))
@@ -589,7 +589,7 @@ Test('Participant service', async (participantTest) => {
         createdDate: new Date(),
         participantCurrencyId: 1
       }
-      ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, payload.currency).returns(participant)
+      ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, payload.currency, 1).returns(participant)
       ParticipantLimitModel.getByParticipantCurrencyId.withArgs(participant.participantCurrencyId).returns(null)
       ParticipantPositionModel.getByParticipantCurrencyId.withArgs(participant.participantCurrencyId).returns(null)
       ParticipantFacade.addLimitAndInitialPosition.withArgs(participant.participantCurrencyId, payload).returns(1)
@@ -630,7 +630,7 @@ Test('Participant service', async (participantTest) => {
         createdDate: new Date(),
         participantCurrencyId: 1
       }
-      ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, payload.currency).returns(participant)
+      ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, payload.currency, 1).returns(participant)
       ParticipantLimitModel.getByParticipantCurrencyId.withArgs(participant.participantCurrencyId).returns(null)
       ParticipantPositionModel.getByParticipantCurrencyId.withArgs(participant.participantCurrencyId).returns(null)
       ParticipantFacade.addLimitAndInitialPosition.withArgs(participant.participantCurrencyId, limitPostionObj).returns(1)
@@ -662,7 +662,7 @@ Test('Participant service', async (participantTest) => {
       createdDate: new Date(),
       participantCurrencyId: 1
     }
-    ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, payload.currency).throws(new Error())
+    ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, payload.currency, 1).throws(new Error())
 
     try {
       await Service.addLimitAndInitialPosition(participant.name, payload)
@@ -690,7 +690,7 @@ Test('Participant service', async (participantTest) => {
       createdDate: new Date(),
       participantCurrencyId: 1
     }
-    ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, payload.currency).returns(participant)
+    ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, payload.currency, 1).returns(participant)
     ParticipantLimitModel.getByParticipantCurrencyId.withArgs(participant.participantCurrencyId).returns(null)
     ParticipantPositionModel.getByParticipantCurrencyId.withArgs(participant.participantCurrencyId).returns(null)
     ParticipantFacade.addLimitAndInitialPosition.withArgs(participant.participantCurrencyId, payload).throws(new Error())
@@ -728,7 +728,7 @@ Test('Participant service', async (participantTest) => {
       reservedValue: 0.0,
       changedDate: new Date()
     }
-    ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, payload.currency).returns(participant)
+    ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, payload.currency, 1).returns(participant)
     ParticipantLimitModel.getByParticipantCurrencyId.withArgs(participant.participantCurrencyId).returns(null)
     ParticipantPositionModel.getByParticipantCurrencyId.withArgs(participant.participantCurrencyId).returns(participantPosition)
     ParticipantFacade.addLimitAndInitialPosition.withArgs(participant.participantCurrencyId, payload).returns(1)
@@ -770,7 +770,7 @@ Test('Participant service', async (participantTest) => {
       createdDate: new Date(),
       createdBy: 'unknown'
     }
-    ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, payload.currency).returns(participant)
+    ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, payload.currency, 1).returns(participant)
     ParticipantLimitModel.getByParticipantCurrencyId.withArgs(participant.participantCurrencyId).returns(participantLimit)
     ParticipantPositionModel.getByParticipantCurrencyId.withArgs(participant.participantCurrencyId).returns(null)
     ParticipantFacade.addLimitAndInitialPosition.withArgs(participant.participantCurrencyId, payload).returns(1)
@@ -794,10 +794,10 @@ Test('Participant service', async (participantTest) => {
         createdDate: new Date(),
         participantCurrencyId: 1
       }
-      ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, participant.currency).returns(participant)
+      ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, participant.currency, 1).returns(participant)
       ParticipantPositionModel.destroyByParticipantCurrencyId.withArgs(participant.participantCurrencyId).returns(1)
 
-      const result = await Service.destroyParticipantPositionByNameAndCurrency(participant.name, participant.currency)
+      const result = await Service.destroyParticipantPositionByNameAndCurrency(participant.name, participant.currency, 1)
       assert.equal(result, 1, 'Results matched')
       assert.end()
     } catch (err) {
@@ -816,10 +816,10 @@ Test('Participant service', async (participantTest) => {
       createdDate: new Date(),
       participantCurrencyId: 1
     }
-    ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, participant.currency).returns(participant)
+    ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, participant.currency, 1).returns(participant)
     ParticipantPositionModel.destroyByParticipantCurrencyId.withArgs(participant.participantCurrencyId).throws(new Error())
     try {
-      await Service.destroyParticipantPositionByNameAndCurrency(participant.name, participant.currency)
+      await Service.destroyParticipantPositionByNameAndCurrency(participant.name, participant.currency, 1)
       assert.fail(' should throw')
     } catch (err) {
       assert.assert(err instanceof Error, ` throws ${err} `)
@@ -837,10 +837,10 @@ Test('Participant service', async (participantTest) => {
         createdDate: new Date(),
         participantCurrencyId: 1
       }
-      ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, participant.currency).returns(participant)
+      ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, participant.currency, 1).returns(participant)
       ParticipantLimitModel.destroyByParticipantCurrencyId.withArgs(participant.participantCurrencyId).returns(1)
 
-      const result = await Service.destroyParticipantLimitByNameAndCurrency(participant.name, participant.currency)
+      const result = await Service.destroyParticipantLimitByNameAndCurrency(participant.name, participant.currency, 1)
       assert.equal(result, 1, 'Results matched')
       assert.end()
     } catch (err) {
@@ -859,10 +859,10 @@ Test('Participant service', async (participantTest) => {
       createdDate: new Date(),
       participantCurrencyId: 1
     }
-    ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, participant.currency).returns(participant)
+    ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, participant.currency, 1).returns(participant)
     ParticipantLimitModel.destroyByParticipantCurrencyId.withArgs(participant.participantCurrencyId).throws(new Error())
     try {
-      await Service.destroyParticipantLimitByNameAndCurrency(participant.name, participant.currency)
+      await Service.destroyParticipantLimitByNameAndCurrency(participant.name, participant.currency, 1)
       assert.fail(' should throw')
     } catch (err) {
       assert.assert(err instanceof Error, ` throws ${err} `)
@@ -969,7 +969,7 @@ Test('Participant service', async (participantTest) => {
         createdDate: new Date(),
         participantCurrencyId: 1
       }
-      ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, payload.currency).returns(participant)
+      ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, payload.currency, 1).returns(participant)
       ParticipantFacade.adjustLimits.withArgs(participant.participantCurrencyId, payload.limit).returns(1)
 
       const result = await Service.adjustLimits(participant.name, payload)
@@ -998,7 +998,7 @@ Test('Participant service', async (participantTest) => {
       createdDate: new Date(),
       participantCurrencyId: 1
     }
-    ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, payload.currency).returns(participant)
+    ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, payload.currency, 1).returns(participant)
     ParticipantFacade.adjustLimits.withArgs(participant.participantCurrencyId, payload.limit).throws(new Error())
 
     try {
@@ -1025,7 +1025,7 @@ Test('Participant service', async (participantTest) => {
         createdDate: new Date(),
         participantCurrencyId: 1
       }
-      ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, participant.currency).returns(participant)
+      ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, participant.currency, 1).returns(participant)
 
       ParticipantFacade.getParticipantLimitsByCurrencyId.withArgs(participant.participantCurrencyId, limit[0].name).returns(P.resolve(limit))
       const result = await Service.getLimits(participant.name, { currency: participant.currency, type: limit[0].name })
@@ -1053,7 +1053,7 @@ Test('Participant service', async (participantTest) => {
         createdDate: new Date(),
         participantCurrencyId: 1
       }
-      ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, participant.currency).returns(participant)
+      ParticipantFacade.getByNameAndCurrency.withArgs(participant.name, participant.currency, 1).returns(participant)
 
       ParticipantFacade.getParticipantLimitsByCurrencyId.withArgs(participant.participantCurrencyId).returns(P.resolve(limit))
       const result = await Service.getLimits(participant.name, { currency: participant.currency })
@@ -1090,7 +1090,7 @@ Test('Participant service', async (participantTest) => {
       }
       ParticipantModel.getByName.withArgs(participant.name).returns(participant)
 
-      ParticipantFacade.getParticipantLimitsByParticipantId.withArgs(participant.participantId, 'NET_DEBIT_CAP').returns(P.resolve(limit))
+      ParticipantFacade.getParticipantLimitsByParticipantId.withArgs(participant.participantId, 'NET_DEBIT_CAP', 1).returns(P.resolve(limit))
       const result = await Service.getLimits(participant.name, { type: 'NET_DEBIT_CAP' })
       assert.deepEqual(result, limit, 'Results matched')
       assert.end()
@@ -1125,7 +1125,7 @@ Test('Participant service', async (participantTest) => {
       }
       ParticipantModel.getByName.withArgs(participant.name).returns(participant)
 
-      ParticipantFacade.getParticipantLimitsByParticipantId.withArgs(participant.participantId).returns(P.resolve(limit))
+      ParticipantFacade.getParticipantLimitsByParticipantId.withArgs(participant.participantId, null, 1).returns(P.resolve(limit))
       const result = await Service.getLimits(participant.name, {})
       assert.deepEqual(result, limit, 'Results matched')
       assert.end()
@@ -1146,12 +1146,12 @@ Test('Participant service', async (participantTest) => {
       participantCurrancyId: 1
     }
     ParticipantModel.getByName.withArgs(participant.name).returns(participant)
-    ParticipantFacade.getParticipantLimitsByParticipantId.withArgs(participant.participantId).throws(new Error())
+    ParticipantFacade.getParticipantLimitsByParticipantId.withArgs(participant.participantId, null, 1).throws(new Error())
     try {
       await Service.getLimits(participant.name, {})
-      assert.fail(' should throw')
+      assert.fail('should throw')
     } catch (err) {
-      assert.assert(err instanceof Error, ` throws ${err} `)
+      assert.assert(err instanceof Error, `throws ${err} `)
     }
     assert.end()
   })
@@ -1181,8 +1181,8 @@ Test('Participant service', async (participantTest) => {
         createdDate: new Date(),
         participantCurrencyId: 1
       }
-      ParticipantFacade.getByNameAndCurrency.withArgs(participantName, query.currency).returns(participant)
-      PositionFacade.getByNameAndCurrency.withArgs(participantName, query.currency).returns(P.resolve(positionReturn))
+      ParticipantFacade.getByNameAndCurrency.withArgs(participantName, query.currency, 1).returns(participant)
+      PositionFacade.getByNameAndCurrency.withArgs(participantName, query.currency, 1).returns(P.resolve(positionReturn))
 
       const result = await Service.getPositions(participantName, query)
       assert.deepEqual(result, expected, 'Results matched')
@@ -1209,8 +1209,8 @@ Test('Participant service', async (participantTest) => {
         createdDate: new Date(),
         participantCurrencyId: 1
       }
-      ParticipantFacade.getByNameAndCurrency.withArgs(participantName, query.currency).returns(participant)
-      PositionFacade.getByNameAndCurrency.withArgs(participantName, query.currency).returns(P.resolve(positionReturn))
+      ParticipantFacade.getByNameAndCurrency.withArgs(participantName, query.currency, 1).returns(participant)
+      PositionFacade.getByNameAndCurrency.withArgs(participantName, query.currency, 1).returns(P.resolve(positionReturn))
 
       const result = await Service.getPositions(participantName, query)
       assert.deepEqual(result, expected, 'Results matched')

--- a/testPI2/unit/models/participant/facade.test.js
+++ b/testPI2/unit/models/participant/facade.test.js
@@ -98,9 +98,11 @@ Test('Participant facade', async (facadeTest) => {
         andWhere: sandbox.stub().returns({
           andWhere: sandbox.stub().returns({
             andWhere: sandbox.stub().returns({
-              innerJoin: sandbox.stub().returns({
-                select: sandbox.stub().returns({
-                  first: sandbox.stub().returns(participant)
+              andWhere: sandbox.stub().returns({
+                innerJoin: sandbox.stub().returns({
+                  select: sandbox.stub().returns({
+                    first: sandbox.stub().returns(participant)
+                  })
                 })
               })
             })
@@ -108,7 +110,7 @@ Test('Participant facade', async (facadeTest) => {
         })
       })
 
-      var result = await Model.getByNameAndCurrency({ name: 'fsp1', currencyId: 'USD' })
+      var result = await Model.getByNameAndCurrency({ name: 'fsp1', currencyId: 'USD', ledgerAccountTypeId: 1 })
       assert.deepEqual(result, participant)
       assert.end()
     } catch (err) {
@@ -121,7 +123,7 @@ Test('Participant facade', async (facadeTest) => {
   await facadeTest.test('getByNameAndCurrency should throw error', async (assert) => {
     try {
       Db.participant.query.throws(new Error('message'))
-      await Model.getByNameAndCurrency({ name: 'fsp1', currencyId: 'USD' })
+      await Model.getByNameAndCurrency({ name: 'fsp1', currencyId: 'USD', ledgerAccountTypeId: 1 })
       assert.fail(' should throw')
       assert.end()
     } catch (err) {
@@ -134,7 +136,7 @@ Test('Participant facade', async (facadeTest) => {
   await facadeTest.test('getByNameAndCurrency should throw error when participant not found', async (assert) => {
     try {
       Db.participant.query.throws(new Error('message'))
-      await Model.getByNameAndCurrency({ name: 'fsp3', currencyId: 'USD' })
+      await Model.getByNameAndCurrency({ name: 'fsp3', currencyId: 'USD', ledgerAccountTypeId: 1 })
       assert.fail(' should throw')
       assert.end()
     } catch (err) {
@@ -783,7 +785,7 @@ Test('Participant facade', async (facadeTest) => {
           })
         })
       })
-      var result = await Model.getParticipantLimitsByParticipantId(participant.participantId, 'NET_DEBIT_CAP')
+      var result = await Model.getParticipantLimitsByParticipantId(participant.participantId, 1, 'NET_DEBIT_CAP')
       assert.deepEqual(result, participantLimit)
       assert.end()
     } catch (err) {
@@ -821,7 +823,7 @@ Test('Participant facade', async (facadeTest) => {
           })
         })
       })
-      var result = await Model.getParticipantLimitsByParticipantId(participant.participantId)
+      var result = await Model.getParticipantLimitsByParticipantId(participant.participantId, 1)
       assert.deepEqual(result, participantLimit)
       assert.end()
     } catch (err) {
@@ -838,7 +840,7 @@ Test('Participant facade', async (facadeTest) => {
       builderStub.innerJoin = sandbox.stub()
 
       builderStub.innerJoin.throws(new Error())
-      await Model.getParticipantLimitsByParticipantId(participant.participantId)
+      await Model.getParticipantLimitsByParticipantId(participant.participantId, 1)
       assert.fail(' should throw')
       assert.end()
       assert.end()

--- a/testPI2/unit/models/participant/participantCurrency.test.js
+++ b/testPI2/unit/models/participant/participantCurrency.test.js
@@ -122,7 +122,7 @@ Test('Participant Currency model', async (participantCurrencyTest) => {
 
   await participantCurrencyTest.test('getByParticipantId', async (assert) => {
     try {
-      Db.participantCurrency.find.withArgs({participantId: 1}).returns([{
+      Db.participantCurrency.find.withArgs({participantId: 1, ledgerAccountTypeId: 1}).returns([{
         participantCurrancyId: 1,
         participantId: 1,
         currencyId: 'USD',
@@ -149,7 +149,7 @@ Test('Participant Currency model', async (participantCurrencyTest) => {
           isActive: 1
         }
       ]
-      let result = await Model.getByParticipantId(1)
+      let result = await Model.getByParticipantId(1, 1)
       assert.equal(JSON.stringify(result), JSON.stringify(expected))
       assert.end()
     } catch (err) {
@@ -161,8 +161,8 @@ Test('Participant Currency model', async (participantCurrencyTest) => {
 
   await participantCurrencyTest.test('getByParticipantId should fail', async (test) => {
     try {
-      Db.participantCurrency.find.withArgs({participantId: 1}).throws(new Error())
-      await Model.getByParticipantId(1)
+      Db.participantCurrency.find.withArgs({participantId: 1, ledgerAccountTypeId: 1}).throws(new Error())
+      await Model.getByParticipantId(1, 1)
       test.fail('Error not thrown')
       test.end()
     } catch (err) {

--- a/testPI2/unit/models/position/facade.test.js
+++ b/testPI2/unit/models/position/facade.test.js
@@ -60,6 +60,7 @@ Test('Position facade', async (positionFacadeTest) => {
     try {
       const participantId = 1
       const currencyId = 'USD'
+      const ledgerAccountTypeId = 1
       let builderStub = sandbox.stub()
       let participantCurrencyStub = sandbox.stub()
       let participantPositionStub = sandbox.stub()
@@ -76,11 +77,12 @@ Test('Position facade', async (positionFacadeTest) => {
         })
       })
 
-      let found = await ModelParticipant.getParticipantPositionByParticipantIdAndCurrencyId(participantId, currencyId)
+      let found = await ModelParticipant.getParticipantPositionByParticipantIdAndCurrencyId(participantId, currencyId, ledgerAccountTypeId)
       test.equal(found, 1, 'retrive the record')
       test.ok(builderStub.where.withArgs({
         'participant.participantId': participantId,
-        'pc.currencyId': currencyId
+        'pc.currencyId': currencyId,
+        'pc.ledgerAccountTypeId': ledgerAccountTypeId
       }).calledOnce, 'query builder called once')
       test.ok(participantCurrencyStub.withArgs('participantCurrency AS pc', 'pc.participantId', 'participant.participantId').calledOnce, 'participantCurrency inner joined')
       test.ok(participantPositionStub.withArgs('participantPosition AS pp', 'pp.participantCurrencyId', 'pc.participantCurrencyId').calledOnce, 'participantPosition inner joined')
@@ -101,9 +103,10 @@ Test('Position facade', async (positionFacadeTest) => {
     try {
       const participantId = 1
       const currencyId = 'USD'
+      const ledgerAccountTypeId = 1
       Db.participant.query.throws(new Error())
 
-      await ModelParticipant.getParticipantPositionByParticipantIdAndCurrencyId(participantId, currencyId)
+      await ModelParticipant.getParticipantPositionByParticipantIdAndCurrencyId(participantId, currencyId, ledgerAccountTypeId)
       test.fail('Error not thrown')
       test.end()
     } catch (err) {
@@ -117,6 +120,7 @@ Test('Position facade', async (positionFacadeTest) => {
     try {
       const participantId = 1
       const currencyId = 'USD'
+      const ledgerAccountTypeId = 1
       let builderStub = sandbox.stub()
       let participantCurrencyStub = sandbox.stub()
       let participantLimitStub = sandbox.stub()
@@ -133,11 +137,12 @@ Test('Position facade', async (positionFacadeTest) => {
         })
       })
 
-      let found = await ModelParticipant.getParticipantLimitByParticipantIdAndCurrencyId(participantId, currencyId)
+      let found = await ModelParticipant.getParticipantLimitByParticipantIdAndCurrencyId(participantId, currencyId, ledgerAccountTypeId)
       test.equal(found, 1, 'retrive the record')
       test.ok(builderStub.where.withArgs({
         'participant.participantId': participantId,
-        'pc.currencyId': currencyId
+        'pc.currencyId': currencyId,
+        'pc.ledgerAccountTypeId': ledgerAccountTypeId
       }).calledOnce, 'query builder called once')
       test.ok(participantCurrencyStub.withArgs('participantCurrency AS pc', 'pc.participantId', 'participant.participantId').calledOnce, 'participantCurrency inner joined')
       test.ok(participantLimitStub.withArgs('participantLimit AS pl', 'pl.participantCurrencyId', 'pl.participantCurrencyId').calledOnce, 'participantLimit inner joined')
@@ -158,9 +163,10 @@ Test('Position facade', async (positionFacadeTest) => {
     try {
       const participantId = 1
       const currencyId = 'USD'
+      const ledgerAccountTypeId = 1
       Db.participant.query.throws(new Error())
 
-      await ModelParticipant.getParticipantLimitByParticipantIdAndCurrencyId(participantId, currencyId)
+      await ModelParticipant.getParticipantLimitByParticipantIdAndCurrencyId(participantId, currencyId, ledgerAccountTypeId)
       test.fail('Error not thrown')
       test.end()
     } catch (err) {
@@ -597,6 +603,7 @@ Test('Position facade', async (positionFacadeTest) => {
     try {
       const participantName = 'fsp1'
       const currencyId = 'USD'
+      const ledgerAccountTypeId = 1
       let builderStub = sandbox.stub()
 
       const participantPosition = [
@@ -623,7 +630,7 @@ Test('Position facade', async (positionFacadeTest) => {
         })
       })
 
-      let found = await ModelPosition.getByNameAndCurrency(participantName, currencyId)
+      let found = await ModelPosition.getByNameAndCurrency(participantName, currencyId, ledgerAccountTypeId)
       test.deepEqual(found, participantPosition, 'retrive the record')
       test.ok(builderStub.innerJoin.withArgs('participantCurrency AS pc', 'participantPosition.participantCurrencyId', 'pc.participantCurrencyId').calledOnce, 'query builder called once')
 
@@ -638,6 +645,7 @@ Test('Position facade', async (positionFacadeTest) => {
   await positionFacadeTest.test('getByNameAndCurrency should return the participant positions for all currencies', async (test) => {
     try {
       const participantName = 'fsp1'
+      const ledgerAccountTypeId = 1
       let builderStub = sandbox.stub()
 
       const participantPosition = [
@@ -671,7 +679,7 @@ Test('Position facade', async (positionFacadeTest) => {
         })
       })
 
-      let found = await ModelPosition.getByNameAndCurrency(participantName)
+      let found = await ModelPosition.getByNameAndCurrency(participantName, null, ledgerAccountTypeId)
       test.deepEqual(found, participantPosition, 'retrive the record')
       test.ok(builderStub.innerJoin.withArgs('participantCurrency AS pc', 'participantPosition.participantCurrencyId', 'pc.participantCurrencyId').calledOnce, 'query builder called once')
 
@@ -687,10 +695,11 @@ Test('Position facade', async (positionFacadeTest) => {
     try {
       const participantName = 'fsp1'
       const currencyId = 'USD'
+      const ledgerAccountTypeId = 1
 
       Db.participantPosition.query.throws(new Error())
 
-      await ModelPosition.getByNameAndCurrency(participantName, currencyId)
+      await ModelPosition.getByNameAndCurrency(participantName, currencyId, ledgerAccountTypeId)
       test.fail(' should throw')
       test.end()
       test.end()

--- a/testPI2/unit/models/transfer/facade.test.js
+++ b/testPI2/unit/models/transfer/facade.test.js
@@ -722,8 +722,8 @@ Test('Transfer facade', async (transferFacadeTest) => {
 
   await transferFacadeTest.test('saveTransferPrepared save prepared transfer', async (test) => {
     try {
-      ParticipantFacade.getByNameAndCurrency.withArgs('dfsp1', 'USD').returns('dfsp1', 1)
-      ParticipantFacade.getByNameAndCurrency.withArgs('dfsp2', 'USD').returns('dfsp2', 2)
+      ParticipantFacade.getByNameAndCurrency.withArgs('dfsp1', 'USD', 1).returns('dfsp1', 1)
+      ParticipantFacade.getByNameAndCurrency.withArgs('dfsp2', 'USD', 1).returns('dfsp2', 2)
 
       sandbox.stub(Db, 'getKnex')
       const knexStub = sandbox.stub()
@@ -755,8 +755,8 @@ Test('Transfer facade', async (transferFacadeTest) => {
 
   await transferFacadeTest.test('saveTransferPrepared save prepared transfer default', async (test) => {
     try {
-      ParticipantFacade.getByNameAndCurrency.withArgs('dfsp1', 'USD').returns('dfsp1', 1)
-      ParticipantFacade.getByNameAndCurrency.withArgs('dfsp2', 'USD').returns('dfsp2', 2)
+      ParticipantFacade.getByNameAndCurrency.withArgs('dfsp1', 'USD', 1).returns('dfsp1', 1)
+      ParticipantFacade.getByNameAndCurrency.withArgs('dfsp2', 'USD', 1).returns('dfsp2', 2)
 
       sandbox.stub(Db, 'getKnex')
       const knexStub = sandbox.stub()
@@ -788,8 +788,8 @@ Test('Transfer facade', async (transferFacadeTest) => {
 
   await transferFacadeTest.test('saveTransferPrepared save prepared transfer -without extensionList', async (test) => {
     try {
-      ParticipantFacade.getByNameAndCurrency.withArgs('dfsp1', 'USD').returns('dfsp1', 1)
-      ParticipantFacade.getByNameAndCurrency.withArgs('dfsp2', 'USD').returns('dfsp2', 2)
+      ParticipantFacade.getByNameAndCurrency.withArgs('dfsp1', 'USD', 1).returns('dfsp1', 1)
+      ParticipantFacade.getByNameAndCurrency.withArgs('dfsp2', 'USD', 1).returns('dfsp2', 2)
 
       sandbox.stub(Db, 'getKnex')
       const knexStub = sandbox.stub()
@@ -823,8 +823,8 @@ Test('Transfer facade', async (transferFacadeTest) => {
 
   await transferFacadeTest.test('saveTransferPrepared save invalid prepared transfer', async (test) => {
     try {
-      ParticipantFacade.getByNameAndCurrency.withArgs('dfsp1', 'USD').returns('dfsp1', 1)
-      ParticipantFacade.getByNameAndCurrency.withArgs('dfsp2', 'USD').returns('dfsp2', 2)
+      ParticipantFacade.getByNameAndCurrency.withArgs('dfsp1', 'USD', 1).returns('dfsp1', 1)
+      ParticipantFacade.getByNameAndCurrency.withArgs('dfsp2', 'USD', 1).returns('dfsp2', 2)
 
       sandbox.stub(Db, 'getKnex')
       const knexStub = sandbox.stub()
@@ -856,8 +856,8 @@ Test('Transfer facade', async (transferFacadeTest) => {
 
   await transferFacadeTest.test('saveTransferPrepared throw error', async (test) => {
     try {
-      ParticipantFacade.getByNameAndCurrency.withArgs('dfsp1', 'USD').returns('dfsp1', 1)
-      ParticipantFacade.getByNameAndCurrency.withArgs('dfsp2', 'USD').returns('dfsp2', 2)
+      ParticipantFacade.getByNameAndCurrency.withArgs('dfsp1', 'USD', 1).returns('dfsp1', 1)
+      ParticipantFacade.getByNameAndCurrency.withArgs('dfsp2', 'USD', 1).returns('dfsp2', 2)
 
       sandbox.stub(Db, 'getKnex')
       const knexStub = sandbox.stub()

--- a/testPI2/unit/shared/setup.test.js
+++ b/testPI2/unit/shared/setup.test.js
@@ -35,6 +35,7 @@ Test('setup', setupTest => {
     serverStub = {
       connection: sandbox.stub(),
       register: sandbox.stub(),
+      method: sandbox.stub(),
       ext: sandbox.stub(),
       start: sandbox.stub(),
       info: {


### PR DESCRIPTION
[Story #461](https://github.com/mojaloop/project/issues/461)
- [x] 3. Implement changes to the database, incl. seeds
  - [x] 3.1. Implement server cached enums in central-ledger
- [x] 5. Update central-ledger codebase so that all references to participantCurrencyId point to the _Position Account_
- [x] 6. Update central-ledger admin api so that both accounts (Position & Settlement) are created in place of the currently created sole account (participantCurrency entry)

`npm run test:int`
```
1..119
# tests 119
# pass  119

# ok
```

```
=============================== Coverage summary ===============================
Statements   : 67.42% ( 2206/3272 )
Branches     : 61.99% ( 473/763 )
Functions    : 51% ( 281/551 )
Lines        : 67.91% ( 2192/3228 )
================================================================================

1..769
# tests 769
# pass  769

# ok
```