### PR TITLE
Fixed the listed occurrences of local timestamps

### DIFF
--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -41,7 +41,7 @@ const getCurrentUTCTimeInMilliseconds = () => {
 }
 
 const getUTCString = (d) => {
-  return d.toISOString().replace(/[TZ]/, ' ').trim()
+  return d.toISOString().replace(/[TZ]/g, ' ').trim()
   // return new Date(d.getTime() + d.getTimezoneOffset() * 60000)
 }
 

--- a/src/models/position/facade.js
+++ b/src/models/position/facade.js
@@ -35,6 +35,8 @@ const Enum = require('../../lib/enum')
 const participantFacade = require('../participant/facade')
 const Errors = require('../../lib/errors')
 const Logger = require('@mojaloop/central-services-shared').Logger
+const Time = require('../../lib/time')
+
 const prepareChangeParticipantPositionTransaction = async (transferList) => {
   try {
     const knex = await Db.getKnex()
@@ -185,7 +187,7 @@ const changeParticipantPositionTransaction = async (participantCurrencyId, isRev
     const knex = await Db.getKnex()
     await knex.transaction(async (trx) => {
       try {
-        const transactionTimestamp = new Date()
+        const transactionTimestamp = Time.getUTCString(new Date())
         transferStateChange.createdDate = transactionTimestamp
         const participantPosition = await knex('participantPosition').transacting(trx).where({ participantCurrencyId }).forUpdate().select('*').first()
         let latestPosition

--- a/testPI2/integration/helpers/testProducer.js
+++ b/testPI2/integration/helpers/testProducer.js
@@ -37,6 +37,7 @@ const TransferEventType = Enum.transferEventType
 const TransferEventAction = Enum.transferEventAction
 const amount = parseFloat(Number(Math.floor(Math.random() * 100 * 100) / 100 + 100).toFixed(2)) // decimal amount between 100.01 and 200.00
 const expiration = new Date((new Date()).getTime() + (24 * 60 * 60 * 1000)) // tomorrow
+const Time = require('../../../src/lib/time')
 
 const transfer = {
   transferId: Uuid(),
@@ -48,7 +49,7 @@ const transfer = {
   },
   ilpPacket: 'AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA',
   condition: '47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU',
-  expiration,
+  expiration: Time.getUTCString(expiration),
   extensionList: {
     extension: [
       {
@@ -65,7 +66,7 @@ const transfer = {
 
 const fulfil = {
   fulfilment: 'oAKAAA',
-  completedTimestamp: new Date(),
+  completedTimestamp: Time.getUTCString(new Date()),
   transferState: TransferState.COMMITTED,
   extensionList: {
     extension: [

--- a/testPI2/integration/helpers/transferDuplicateCheck.js
+++ b/testPI2/integration/helpers/transferDuplicateCheck.js
@@ -26,7 +26,7 @@
 
 const Model = require('../../../src/models/transfer/transferDuplicateCheck')
 const ParticipantPreparationModule = require('./participant')
-// const time = require('../../../src/lib/time')
+const Time = require('../../../src/lib/time')
 const Crypto = require('crypto')
 const Uuid = require('uuid4')
 
@@ -45,7 +45,7 @@ exports.prepareData = async () => {
       },
       condition: 'YlK5TZyhflbXaDRPtR5zhCu8FrbgvrQwwmzuH0iQ0AI',
       ilpPacket: 'AQAAAAAAAABkEGcuZXdwMjEuaWQuODAwMjCCAhd7InRyYW5zYWN0aW9uSWQiOiJmODU0NzdkYi0xMzVkLTRlMDgtYThiNy0xMmIyMmQ4MmMwZDYiLCJxdW90ZUlkIjoiOWU2NGYzMjEtYzMyNC00ZDI0LTg5MmYtYzQ3ZWY0ZThkZTkxIiwicGF5ZWUiOnsicGFydHlJZEluZm8iOnsicGFydHlJZFR5cGUiOiJNU0lTRE4iLCJwYXJ0eUlkZW50aWZpZXIiOiIyNTYxMjM0NTYiLCJmc3BJZCI6IjIxIn19LCJwYXllciI6eyJwYXJ0eUlkSW5mbyI6eyJwYXJ0eUlkVHlwZSI6Ik1TSVNETiIsInBhcnR5SWRlbnRpZmllciI6IjI1NjIwMTAwMDAxIiwiZnNwSWQiOiIyMCJ9LCJwZXJzb25hbEluZm8iOnsiY29tcGxleE5hbWUiOnsiZmlyc3ROYW1lIjoiTWF0cyIsImxhc3ROYW1lIjoiSGFnbWFuIn0sImRhdGVPZkJpcnRoIjoiMTk4My0xMC0yNSJ9fSwiYW1vdW50Ijp7ImFtb3VudCI6IjEwMCIsImN1cnJlbmN5IjoiVVNEIn0sInRyYW5zYWN0aW9uVHlwZSI6eyJzY2VuYXJpbyI6IlRSQU5TRkVSIiwiaW5pdGlhdG9yIjoiUEFZRVIiLCJpbml0aWF0b3JUeXBlIjoiQ09OU1VNRVIifSwibm90ZSI6ImhlaiJ9',
-      expiration: new Date()
+      expiration: new Date((new Date()).getTime() + (24 * 60 * 60 * 1000)) // tomorrow
 
     }
     let transfer = {
@@ -53,7 +53,7 @@ exports.prepareData = async () => {
       amount: payload.amount.amount,
       currencyId: payload.amount.currency,
       ilpCondition: payload.condition,
-      expirationDate: payload.expiration
+      expirationDate: Time.getUTCString(payload.expiration)
     }
 
     const hashSha256 = Crypto.createHash('sha256')

--- a/testPI2/integration/helpers/transferExtension.js
+++ b/testPI2/integration/helpers/transferExtension.js
@@ -31,6 +31,7 @@ const TransferPreparationModule = require('./transfer')
 const TransferModel = require('../../../src/models/transfer/transfer')
 const Model = require('../../../src/models/transfer/transferExtension')
 const TransferDuplicateCheckPreparationModule = require('./transferDuplicateCheck')
+const Time = require('../../../src/lib/time')
 
 exports.prepareData = async () => {
   try {
@@ -42,7 +43,7 @@ exports.prepareData = async () => {
       transferId: transferResult.transfer.transferId,
       key: 'extension.key',
       value: 'extension.value',
-      createdDate: new Date()
+      createdDate: Time.getUTCString(new Date())
     })
     let transfer = await TransferModel.getById(transferResult.transfer.transferId)
     let extension = await Model.getByTransferId(transferResult.transfer.transferId)

--- a/testPI2/integration/helpers/transferTestHelper.js
+++ b/testPI2/integration/helpers/transferTestHelper.js
@@ -37,7 +37,7 @@ const TransferFacade = require('../../../src/models/transfer/facade')
 const TransferFulfilmentModel = require('../../../src/models/transfer/transferFulfilment')
 const TransferParticipantModel = require('../../../src/models/transfer/transferParticipant')
 const Enum = require('../../../src/lib/enum')
-
+const Time = require('../../../src/lib/time')
 const Uuid = require('uuid4')
 
 // TODO: add data to transferParticipant, transferParticipantRoleType, transferFulfilment
@@ -52,9 +52,9 @@ exports.prepareData = async () => {
 
     await TransferExtensionModel.saveTransferExtension({
       transferId: transferResult.transfer.transferId,
-      key: 'extension.key',
-      value: 'extension.value',
-      createdDate: new Date()
+      key: 'helper.extension.key',
+      value: 'helper.extension.value',
+      createdDate: Time.getUTCString(new Date())
     })
 
     await IlpModel.saveIlpPacket({
@@ -76,10 +76,10 @@ exports.prepareData = async () => {
     await TransferFulfilmentModel.saveTransferFulfilment({
       transferFulfilmentId: Uuid(),
       transferId: transferResult.transfer.transferId,
-      ilpFulfilment: 'oAKAAA',
-      completedDate: new Date(),
+      ilpFulfilment: 'helper.oAKAAA',
+      completedDate: Time.getUTCString(new Date()),
       isValid: true,
-      createdDate: new Date()
+      createdDate: Time.getUTCString(new Date())
     })
 
     await TransferParticipantModel.saveTransferParticipant({

--- a/testPI2/integration/models/transfer/facade.test.js
+++ b/testPI2/integration/models/transfer/facade.test.js
@@ -30,11 +30,11 @@
 'use strict'
 
 const Test = require('tape')
-const Db = require('../../../../src/db/index')
+const Db = require('../../../../src/db')
 const Logger = require('@mojaloop/central-services-shared').Logger
 const Config = require('../../../../src/lib/config')
 const TransferFacade = require('../../../../src/models/transfer/facade')
-const HelperModule = require('../../helpers/index')
+const HelperModule = require('../../helpers')
 
 Test('Transfer read model test', async (transferReadModelTest) => {
   var transferPrepareResult = {}

--- a/testPI2/integration/models/transfer/transferStateChange.test.js
+++ b/testPI2/integration/models/transfer/transferStateChange.test.js
@@ -34,6 +34,7 @@ const Logger = require('@mojaloop/central-services-shared').Logger
 const Config = require('../../../../src/lib/config')
 const Model = require('../../../../src/models/transfer/transferStateChange')
 const HelperModule = require('../../helpers')
+const Time = require('../../../../src/lib/time')
 
 Test('Transfer State Change model test', async (stateChangeTest) => {
   var stateChangePrepareResult = {}
@@ -58,7 +59,7 @@ Test('Transfer State Change model test', async (stateChangeTest) => {
     try {
       // Prepare helper tests actually the Model.saveTransferExtension and Model.getByTransferId
       stateChangePrepareResult = await HelperModule.prepareNeededData('transferStateChange')
-      assert.comment('the prepared data are: ', JSON.stringify(stateChangePrepareResult, null, 4))
+      assert.comment('the prepared data is: ', JSON.stringify(stateChangePrepareResult, null, 4))
 
       let state = stateChangePrepareResult.transferStateResults[1]
       let createdId = 0
@@ -67,7 +68,7 @@ Test('Transfer State Change model test', async (stateChangeTest) => {
         transferId: stateChangePrepareResult.transfer.transferId,
         transferStateId: state.transferStateId,
         reason: null,
-        createdDate: new Date()
+        createdDate: Time.getUTCString(new Date())
       }
 
       createdId = await Model.saveTransferStateChange(transferStateChange)

--- a/testPI2/unit/models/transfer/facade.test.js
+++ b/testPI2/unit/models/transfer/facade.test.js
@@ -36,6 +36,7 @@ const transferExtensionModel = require('../../../../src/models/transfer/transfer
 const Enum = require('../../../../src/lib/enum')
 const Proxyquire = require('proxyquire')
 const ParticipantFacade = require('../../../../src/models/participant/facade')
+const Time = require('../../../../src/lib/time')
 
 Test('Transfer facade', async (transferFacadeTest) => {
   let sandbox
@@ -469,8 +470,8 @@ Test('Transfer facade', async (transferFacadeTest) => {
       const stateReason = null
       let hasPassedValidation = null
       const saveTransferFulfiledExecuted = true
-      const transferFulfilmentRecord = { transferFulfilmentId: 'tf1', transferId, ilpFulfilment: 'f1', completedDate: now, isValid: true, createdDate: now, settlementWindowId: 1 }
-      const transferStateChangeRecord = { transferId, transferStateId: 'state', reason: stateReason, createdDate: now }
+      const transferFulfilmentRecord = { transferFulfilmentId: 'tf1', transferId, ilpFulfilment: 'f1', completedDate: Time.getUTCString(now), isValid: true, createdDate: Time.getUTCString(now), settlementWindowId: 1 }
+      const transferStateChangeRecord = { transferId, transferStateId: 'state', reason: stateReason, createdDate: Time.getUTCString(now) }
       let transferExtensionRecords = transferExtensions.map(ext => {
         return {
           transferId: transferFulfilmentRecord.transferId,
@@ -501,7 +502,7 @@ Test('Transfer facade', async (transferFacadeTest) => {
 
           let builderStub = sandbox.stub()
           let selectStub = sandbox.stub()
-          let whereRawStub = sandbox.stub()
+          let whereStub = sandbox.stub()
           let orderByStub = sandbox.stub()
           let firstStub = sandbox.stub()
 
@@ -511,7 +512,7 @@ Test('Transfer facade', async (transferFacadeTest) => {
 
           builderStub.leftJoin.returns({
             select: selectStub.returns({
-              whereRaw: whereRawStub.returns({
+              where: whereStub.returns({
                 orderBy: orderByStub.returns({
                   first: firstStub.returns(record)
                 })
@@ -562,7 +563,7 @@ Test('Transfer facade', async (transferFacadeTest) => {
 
           let builderStub = sandbox.stub()
           let selectStub = sandbox.stub()
-          let whereRawStub = sandbox.stub()
+          let whereStub = sandbox.stub()
           let orderByStub = sandbox.stub()
           let firstStub = sandbox.stub()
 
@@ -572,7 +573,7 @@ Test('Transfer facade', async (transferFacadeTest) => {
 
           builderStub.leftJoin.returns({
             select: selectStub.returns({
-              whereRaw: whereRawStub.returns({
+              where: whereStub.returns({
                 orderBy: orderByStub.returns({
                   first: firstStub.returns(record)
                 })
@@ -622,7 +623,7 @@ Test('Transfer facade', async (transferFacadeTest) => {
 
           let builderStub = sandbox.stub()
           let selectStub = sandbox.stub()
-          let whereRawStub = sandbox.stub()
+          let whereStub = sandbox.stub()
           let orderByStub = sandbox.stub()
           let firstStub = sandbox.stub()
 
@@ -632,7 +633,7 @@ Test('Transfer facade', async (transferFacadeTest) => {
 
           builderStub.leftJoin.returns({
             select: selectStub.returns({
-              whereRaw: whereRawStub.returns({
+              where: whereStub.returns({
                 orderBy: orderByStub.returns({
                   first: firstStub.returns(record)
                 })


### PR DESCRIPTION
[Story #486](https://github.com/mojaloop/project/issues/486)

```
=============================== Coverage summary ===============================
Statements   : 66.76% ( 2219/3324 )
Branches     : 61.29% ( 475/775 )
Functions    : 51.09% ( 282/552 )
Lines        : 67.23% ( 2205/3280 )
================================================================================

1..769
# tests 769
# pass  769

# ok
```

`npm run test:int` run @ 2018-10-02 15:00:30 GMT:
```
1..119
# tests 119
# pass  119

# ok
```
Result in data shown by statements:
```
USE central_ledger;
-- SELECT * FROM migration ORDER BY 1 DESC;
SELECT * FROM participantPosition ORDER BY 1 DESC;
SELECT * FROM participantPositionChange ORDER BY 1 DESC;
SELECT * FROM transfer ORDER BY createdDate DESC;
SELECT * FROM transferExtension ORDER BY 1 DESC;
SELECT * FROM transferFulfilment ORDER BY createdDate DESC;
SELECT * FROM transferStateChange ORDER BY 1 DESC;
```
as follows:

<img width="529" alt="participantposition" src="https://user-images.githubusercontent.com/20338055/46358038-c8a8ad80-c66e-11e8-9548-b49bf17bd79f.png">

<img width="694" alt="participantpositionchange" src="https://user-images.githubusercontent.com/20338055/46358046-cfcfbb80-c66e-11e8-822d-e68fdc221cd5.png">

<img width="890" alt="transfer" src="https://user-images.githubusercontent.com/20338055/46358052-d4946f80-c66e-11e8-863d-f4295c0b5524.png">

<img width="994" alt="transferextenstion" src="https://user-images.githubusercontent.com/20338055/46358066-d8c08d00-c66e-11e8-96a7-cd6390d78fa4.png">

<img width="792" alt="transferfulfilment" src="https://user-images.githubusercontent.com/20338055/46358074-deb66e00-c66e-11e8-95e5-68743b34b54b.png">

<img width="877" alt="transferstatechange" src="https://user-images.githubusercontent.com/20338055/46358080-e249f500-c66e-11e8-9bb1-a347cf9b98b6.png">