### PR TITLE
updates to enable topic configuration for kafka producers

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -305,6 +305,9 @@
               "queue.buffering.max.ms": 1,
               "broker.version.fallback": "0.10.1.0",
               "api.version.request": true
+            },
+            "topicConf": {
+              "request.required.acks": "all"
             }
           }
         },
@@ -329,6 +332,9 @@
               "queue.buffering.max.ms": 1,
               "broker.version.fallback": "0.10.1.0",
               "api.version.request": true
+            },
+            "topicConf": {
+              "request.required.acks": "all"
             }
           }
         },
@@ -353,6 +359,9 @@
               "queue.buffering.max.ms": 1,
               "broker.version.fallback": "0.10.1.0",
               "api.version.request": true
+            },
+            "topicConf": {
+              "request.required.acks": "all"
             }
           }
         }
@@ -379,6 +388,9 @@
               "queue.buffering.max.ms": 1,
               "broker.version.fallback": "0.10.1.0",
               "api.version.request": true
+            },
+            "topicConf": {
+              "request.required.acks": "all"
             }
           }
         },
@@ -403,6 +415,9 @@
               "queue.buffering.max.ms": 1,
               "broker.version.fallback": "0.10.1.0",
               "api.version.request": true
+            },
+            "topicConf": {
+              "request.required.acks": "all"
             }
           }
         },
@@ -427,6 +442,9 @@
               "queue.buffering.max.ms": 1,
               "broker.version.fallback": "0.10.1.0",
               "api.version.request": true
+            },
+            "topicConf": {
+              "request.required.acks": "all"
             }
           }
         }
@@ -454,6 +472,9 @@
               "broker.version.fallback": "0.10.1.0",
               "api.version.request": true,
               "partitioner": "random"
+            },
+            "topicConf": {
+              "request.required.acks": "all"
             }
           }
         }

--- a/src/handlers/lib/utility.js
+++ b/src/handlers/lib/utility.js
@@ -383,9 +383,10 @@ const createTransferMessageProtocol = (payload, type, action, state, pp = '') =>
 const createParticipantTopicConf = (participantName, functionality, action, partition = null, opaqueKey = 0) => {
   return {
     topicName: transformAccountToTopicName(participantName, functionality, action),
-    key: Uuid(),
+    key: participantName,
     partition,
-    opaqueKey
+    opaqueKey,
+    'request.required.acks': Config
   }
 }
 
@@ -402,7 +403,7 @@ const createParticipantTopicConf = (participantName, functionality, action, part
 const createGeneralTopicConf = (functionality, action, partition = null, opaqueKey = 0) => {
   return {
     topicName: transformGeneralTopicName(functionality, action),
-    key: Uuid(),
+    key: null,
     partition,
     opaqueKey
   }


### PR DESCRIPTION
enabled topic configuration for producers as we as removed the key for general topic messages and changed the key to the fsp name for the participant specific messaged