### PR TITLE
Bugfix/563 Get/Post limits unification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-ledger",
-  "version": "4.1.1",
+  "version": "4.3.1",
   "description": "Central ledger hosted by a scheme to record and settle transfers.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/admin/participants/handler.js
+++ b/src/admin/participants/handler.js
@@ -253,7 +253,7 @@ const adjustLimits = async function (request, h) {
       limit: {
         type: request.payload.limit.type,
         value: participantLimit.value,
-        thresholdAlarmPercentage: participantLimit.thresholdAlarmPercentage
+        alarmPercentage: participantLimit.thresholdAlarmPercentage
       }
 
     }

--- a/src/admin/participants/routes.js
+++ b/src/admin/participants/routes.js
@@ -179,7 +179,7 @@ module.exports = [
     }
   },
   {
-    method: 'POST',
+    method: 'PUT',
     path: '/participants/{name}/limits',
     handler: Handler.adjustLimits,
     options: {
@@ -196,7 +196,7 @@ module.exports = [
           limit: Joi.object().keys({
             type: Joi.string().required().description('Limit Type'),
             value: Joi.number().required().description('Limit Value'),
-            thresholdAlarmPercentage: Joi.number().required().description('limit threshold alarm percentage value')
+            alarmPercentage: Joi.number().required().description('limit threshold alarm percentage value')
           }).required().description('Participant Limit')
         },
         params: {

--- a/src/models/participant/facade.js
+++ b/src/models/participant/facade.js
@@ -355,7 +355,7 @@ const adjustLimits = async (participantCurrencyId, limit, trx) => {
           participantCurrencyId: participantCurrencyId,
           participantLimitTypeId: limitType.participantLimitTypeId,
           value: limit.value,
-          thresholdAlarmPercentage: limit.thresholdAlarmPercentage,
+          thresholdAlarmPercentage: limit.alarmPercentage,
           isActive: 1,
           createdBy: 'unknown'
         }

--- a/test/unit/admin/participants/handler.test.js
+++ b/test/unit/admin/participants/handler.test.js
@@ -754,7 +754,8 @@ Test('Participant', participantHandlerTest => {
         currency: 'USD',
         limit: {
           type: 'NET_DEBIT_CAP',
-          value: 10000000
+          value: 10000000,
+          alarmPercentage: 5
         }
       }
       let participantLimit = {
@@ -763,7 +764,8 @@ Test('Participant', participantHandlerTest => {
         value: payload.limit.value,
         isActive: 1,
         createdBy: 'unknown',
-        participantLimitId: 1
+        participantLimitId: 1,
+        thresholdAlarmPercentage: 5
       }
 
       const expected = {
@@ -771,7 +773,7 @@ Test('Participant', participantHandlerTest => {
         limit: {
           type: 'NET_DEBIT_CAP',
           value: 10000000,
-          thresholdAlarmPercentage: undefined
+          alarmPercentage: 5
         }
       }
 


### PR DESCRIPTION
Issue fixed. Full test coverage is provided. GET is left unchanged.
POST was changed to PUT with the following payload:

`PUT http://{{CL}}/participants/dfsp1/limits`
```
{
  "currency": "USD",
  "limit": {
    "type": "NET_DEBIT_CAP",
    "value": 5000,
    "alarmPercentage": 20
  }
}
```
now returns:
```
{
    "currency": "USD",
    "limit": {
        "type": "NET_DEBIT_CAP",
        "value": 5000,
        "alarmPercentage": 20
    }
}
```