### PR TITLE
762 optimize dockerfiles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults_working_directory: &defaults_working_directory
 
 defaults_docker_node: &defaults_docker_node
   docker:
-    - image: mhart/alpine-node:10.15.1
+    - image: node:10.15.3-alpine
 
 defaults_docker_helm_kube: &defaults_docker_helm_kube
   docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,20 @@
-FROM mhart/alpine-node:10.15.1
-
+FROM node:10.15.3-alpine
 WORKDIR /opt/central-ledger
-COPY . /opt/central-ledger
 
 RUN apk add --no-cache -t build-dependencies git make gcc g++ python libtool autoconf automake \
     && cd $(npm root -g)/npm \
     && npm config set unsafe-perm true \
     && npm install -g node-gyp
 
+COPY package.json package-lock.json* /opt/central-ledger/
 RUN npm install --production
 
 RUN apk del build-dependencies
 
+COPY src /opt/central-ledger/src
+COPY config /opt/central-ledger/config
+COPY migrations /opt/central-ledger/migrations
+COPY seeds /opt/central-ledger/seeds
+
 EXPOSE 3001
-CMD npm run start
+CMD ["npm", "run", "start"]

--- a/test-integration.Dockerfile
+++ b/test-integration.Dockerfile
@@ -1,28 +1,27 @@
-FROM mhart/alpine-node:10.15.1
+FROM node:10.15.3-alpine
 USER root
 
 WORKDIR /opt/central-ledger
-COPY src /opt/central-ledger/src
 
-COPY test /opt/central-ledger/test
+RUN apk add --no-cache -t build-dependencies make gcc g++ python libtool autoconf automake \
+  && cd $(npm root -g)/npm \
+  && npm config set unsafe-perm true \
+  && npm install -g node-gyp tape tap-xunit \
+  && apk --no-cache add git
+
+COPY package.json package-lock.json* /opt/central-ledger/
+RUN npm install
+
+RUN apk del build-dependencies
+
+COPY src /opt/central-ledger/src
+COPY config /opt/central-ledger/config
 COPY migrations /opt/central-ledger/migrations
 COPY seeds /opt/central-ledger/seeds
-COPY config /opt/central-ledger/config
-COPY package.json server.sh /opt/central-ledger/
+COPY test /opt/central-ledger/test
 
 # overwrite default.json with integration environment specific config
 RUN cp -f /opt/central-ledger/test/integration-config.json /opt/central-ledger/config/default.json
-
-RUN apk add --no-cache -t build-dependencies make gcc g++ python libtool autoconf automake \
-    && cd $(npm root -g)/npm \
-    && npm config set unsafe-perm true \
-    && npm install -g node-gyp \
-    && apk --no-cache add git
-
-RUN npm install -g tape tap-xunit \
-    && npm install
-
-RUN apk del build-dependencies
 
 EXPOSE 3001
 CMD ["/opt/central-ledger/server.sh"]

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,25 +1,24 @@
-FROM mhart/alpine-node:10.15.1
+FROM node:10.15.3-alpine
 USER root
 
 WORKDIR /opt/central-ledger
-COPY src /opt/central-ledger/src
-
-COPY test /opt/central-ledger/test
-COPY migrations /opt/central-ledger/migrations
-COPY seeds /opt/central-ledger/seeds
-COPY config /opt/central-ledger/config
-COPY package.json server.sh /opt/central-ledger/
 
 RUN apk add --no-cache -t build-dependencies git make gcc g++ python libtool autoconf automake \
     && cd $(npm root -g)/npm \
     && npm config set unsafe-perm true \
-    && npm install -g node-gyp \
+    && npm install -g node-gyp tape tap-xunit \
     && apk --no-cache add git
 
-RUN npm install -g tape tap-xunit \
-    && npm install
+COPY package.json package-lock.json* /opt/central-ledger/
+RUN npm install
 
 RUN apk del build-dependencies
+
+COPY src /opt/central-ledger/src
+COPY config /opt/central-ledger/config
+COPY migrations /opt/central-ledger/migrations
+COPY seeds /opt/central-ledger/seeds
+COPY test /opt/central-ledger/test
 
 EXPOSE 3001
 CMD ["/opt/central-ledger/server.sh"]

--- a/test/integration-runner.sh
+++ b/test/integration-runner.sh
@@ -184,7 +184,7 @@ is_db_up() {
 stop_docker
 
 >&1 echo "Building Docker Image $DOCKER_IMAGE:$DOCKER_TAG with $DOCKER_FILE"
-docker build --no-cache -t $DOCKER_IMAGE:$DOCKER_TAG -f $DOCKER_FILE .
+docker build --cache-from $DOCKER_IMAGE:$DOCKER_TAG -t $DOCKER_IMAGE:$DOCKER_TAG -f $DOCKER_FILE .
 
 if [ "$?" != 0 ]
 then


### PR DESCRIPTION
Part of https://github.com/mojaloop/project/issues/762

- Reordered and optimized the commands for `Dockerfile`, `test-integration.Dockerfile` and `test.Dockerfile` to take better advantage of docker layer caching.
- Changed base image to official alpine image to `node:10.15.3-alpine`
- Added a `--cache-from` flag in the functional test runner to improve performance of running functional tests locally

All of these images build and test locally just fine.