### PR TITLE
Updated field in transferRules table for Quoting service

### DIFF
--- a/migrations/501300_transferRules.js
+++ b/migrations/501300_transferRules.js
@@ -5,7 +5,7 @@
  The Mojaloop files are made available by the Bill & Melinda Gates Foundation under the Apache License, Version 2.0 (the "License") and you may not use these files except in compliance with the License. You may obtain a copy of the License at
  http://www.apache.org/licenses/LICENSE-2.0
  Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
- 
+
  Initial contribution
  --------------------
  The initial functionality and code base was donated by the Mowali project working in conjunction with MTN and Orange as service provides.
@@ -38,7 +38,7 @@ exports.up = (knex, Promise) => {
         t.increments('transferRulesId').primary().notNullable()
         t.string('name', 128).notNullable()
         t.string('description', 512).defaultTo(null).nullable()
-        t.string('rule', 16384).notNullable()
+        t.text('rule').notNullable()
         t.boolean('enabled').defaultTo(true).notNullable()
         t.dateTime('createdDate').defaultTo(knex.fn.now()).notNullable()
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-ledger",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-ledger",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "description": "Central ledger hosted by a scheme to record and settle transfers",
   "license": "Apache-2.0",
   "author": "ModusBox",


### PR DESCRIPTION
Hotfix for the following migration error:
```SQL
migration failed with error: create table `transferRules` (`transferRulesId` int unsigned not null auto_increment primary key, `name` varchar(128) not null, `description` varchar(512) null default null, `rule` varchar(16384) not null, `enabled` boolean not null default '1', `createdDate` datetime not null default CURRENT_TIMESTAMP) - ER_TOO_BIG_FIELDLENGTH: Column length too big for column 'rule' (max = 16383); use BLOB or TEXT instead
```

Changes made:
- Update the `rule` field type to `TEXT`
