### PR TITLE
Feature/remove spdx exceptions package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-ledger",
-  "version": "8.8.2",
+  "version": "8.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "audit:resolve": "SHELL=sh resolve-audit",
     "audit:check": "SHELL=sh check-audit",
     "dep:check": "npx ncu -e 2",
-    "dep:update": "npx ncu -u"
+    "dep:update": "npx ncu -u",
+    "postinstall": "echo 'Removing packages with incompatible licenses' && rm -rf ./node_modules/spdx-exceptions"
   },
   "dependencies": {
     "@hapi/good": "8.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-ledger",
-  "version": "8.8.2",
+  "version": "8.8.3",
   "description": "Central ledger hosted by a scheme to record and settle transfers",
   "license": "Apache-2.0",
   "author": "ModusBox",


### PR DESCRIPTION
This is a somewhat hacky fix, but it does remove a deeply nested package that we don't use which is incompatible with our license policy.

Here's the `npm ls` of the `spdx-exceptions` package:
```
@mojaloop/central-ledger@8.8.2 /Users/lewisdaly/developer/vessels/mojaloop/central-ledger
└─┬ npm-run-all@4.1.5
  └─┬ read-pkg@3.0.0
    └─┬ normalize-package-data@2.5.0
      └─┬ validate-npm-package-license@3.0.4
        └─┬ spdx-expression-parse@3.0.0
          └── spdx-exceptions@2.2.0
```