### PR TITLE
Fixed python docker dependency in circle CI image scan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,7 +240,7 @@ jobs:
       - run:
           name: Install docker dependencies for anchore
           command: |
-            apk add --update py-pip docker python-dev libffi-dev openssl-dev gcc libc-dev make jq npm
+            apk add --update py-pip docker python3-dev libffi-dev openssl-dev gcc libc-dev make jq npm
       - run:
           name: Install general dependencies
           command: *defaults_Dependencies


### PR DESCRIPTION
Changed the docker dependency python-dev to python3-dev as the circleCI tests are failing at the image scan while making a release.
https://app.circleci.com/pipelines/github/mojaloop/central-ledger/631/workflows/ed929c02-0760-43aa-a3f9-3e4c0dc1e182