### PR TITLE
Feature/335 thirdparty callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
     "docker:down": "docker-compose -f docker-compose.yml down -v",
     "docker:clean": "docker-compose -f docker-compose.yml down --rmi local",
     "generate-docs": "node_modules/.bin/jsdoc -c jsdoc.json",
-    "audit:resolve": "SHELL=sh resolve-audit",
-    "audit:check": "SHELL=sh check-audit",
+    "audit:resolve": "SHELL=sh resolve-audit --production",
+    "audit:check": "SHELL=sh check-audit --production",
     "dep:check": "npx ncu -e 2",
     "dep:update": "npx ncu -u"
   },

--- a/seeds/endpointType.js
+++ b/seeds/endpointType.js
@@ -129,7 +129,7 @@ const endpointTypes = [
   {
     name: 'FSPIOP_CALLBACK_URL_BULK_TRANSFER_ERROR',
     description: 'Participant callback URL to which bulk transfer error notifications can be sent'
-  },
+  },``
   {
     name: 'FSPIOP_CALLBACK_URL_AUTHORIZATIONS',
     description: 'Participant callback URL to which authorization requests can be sent'
@@ -137,6 +137,10 @@ const endpointTypes = [
   {
     name: 'FSPIOP_CALLBACK_URL_TRX_REQ_SERVICE',
     description: 'Participant callback URL to which transaction requests can be sent'
+  },
+  {
+    name: 'THIRDPARTY_CALLBACK_URL_TRX_REQ_POST',
+    description: 'Participant callback URL where POST thirdpartyRequests/transactions can be sent'
   }
 ]
 

--- a/seeds/endpointType.js
+++ b/seeds/endpointType.js
@@ -129,7 +129,7 @@ const endpointTypes = [
   {
     name: 'FSPIOP_CALLBACK_URL_BULK_TRANSFER_ERROR',
     description: 'Participant callback URL to which bulk transfer error notifications can be sent'
-  },``
+  },
   {
     name: 'FSPIOP_CALLBACK_URL_AUTHORIZATIONS',
     description: 'Participant callback URL to which authorization requests can be sent'


### PR DESCRIPTION
- Add a new `THIRDPARTY_CALLBACK_URL_TRX_REQ_POST` endpoint.
- Also make `audit:check` and audit:resolve` only look for production dependencies
