### PR TITLE
fix(mojaloop/2525): transfers are not being assigned to a settlementWindow on transfers version=1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,10 @@ jspm_packages
 
 .history
 
+# https://devspace.sh/
+devspace*
+.devspace/**.*
+
 # Add ignores
 *IGNORE*
 *ignore*

--- a/src/models/transfer/facade.js
+++ b/src/models/transfer/facade.js
@@ -336,7 +336,7 @@ const savePayeeTransferResponse = async (transferId, payload, action, fspiopErro
 
     await knex.transaction(async (trx) => {
       try {
-        if (!fspiopError && [TransferEventAction.COMMIT, TransferEventAction.BULK_COMMIT].includes(action)) {
+        if (!fspiopError && [TransferEventAction.COMMIT, TransferEventAction.BULK_COMMIT, TransferEventAction.RESERVE].includes(action)) {
           const res = await Db.from('settlementWindow').query(builder => {
             return builder
               .leftJoin('settlementWindowStateChange AS swsc', 'swsc.settlementWindowStateChangeId', 'settlementWindow.currentStateChangeId')


### PR DESCRIPTION
- Fix for [transfers are not being assigned to a settlementWindow on transfers+json;version=1.1 #2525](https://github.com/mojaloop/project/issues/2525)
- Added devspace patterns to gitignore