### PR TITLE
refactor!: rework bulk handler validation 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2371,9 +2371,9 @@
       "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
     },
     "node_modules/@types/whatwg-url": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.1.tgz",
-      "integrity": "sha512-2YubE1sjj5ifxievI5Ge1sckb9k/Er66HyR2c+3+I6VDUUg1TLPdYYTEbQ+DjRkS4nTxMJhgWfSfMRD2sl2EYQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
       "dependencies": {
         "@types/node": "*",
         "@types/webidl-conversions": "*"
@@ -3033,9 +3033,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.4.tgz",
-      "integrity": "sha512-TdQ3FzguAu5HKPPlr0kYQCyrYUYh8tFM+CMTpxjNzVzxeiJY00Rtuj3LXLHSgiGvmaWlZ8PE+4KyM2thqE38pQ==",
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.5.tgz",
+      "integrity": "sha512-uqrgcjyOaZsHfz7ea8zLRCLe1u+QGUSzMZmvXqO24CDW7DWoW1qiN9folSwa7hSneTSgM2ykDIzF5kcQQ8cwNw==",
       "dependencies": {
         "buffer": "^5.6.0"
       },
@@ -4252,9 +4252,9 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "node_modules/denque": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
-      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
       "engines": {
         "node": ">=0.10"
       }
@@ -8552,9 +8552,9 @@
       }
     },
     "node_modules/kareem": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.5.tgz",
-      "integrity": "sha512-qxCyQtp3ioawkiRNQr/v8xw9KIviMSSNmy+63Wubj7KmMn3g7noRXIZB4vPCAP+ETi2SR8eH6CvmlKZuGpoHOg=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.4.1.tgz",
+      "integrity": "sha512-aJ9opVoXroQUPfovYP5kaj2lM7Jn02Gw13bL0lg9v0V7SaUc0qavPs0Eue7d2DcC3NjqI6QAUElXNsuZSeM+EA=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -9552,11 +9552,11 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.5.0.tgz",
-      "integrity": "sha512-A2l8MjEpKojnhbCM0MK3+UOGUSGvTNNSv7AkP1fsT7tkambrkkqN/5F2y+PhzsV0Nbv58u04TETpkaSEdI2zKA==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.8.1.tgz",
+      "integrity": "sha512-/NyiM3Ox9AwP5zrfT9TXjRKDJbXlLaUDQ9Rg//2lbg8D2A8GXV0VidYYnA/gfdK6uwbnL4FnAflH7FbGw3TS7w==",
       "dependencies": {
-        "bson": "^4.6.2",
+        "bson": "^4.6.5",
         "denque": "^2.0.1",
         "mongodb-connection-string-url": "^2.5.2",
         "socks": "^2.6.2"
@@ -9569,22 +9569,22 @@
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.2.tgz",
-      "integrity": "sha512-tWDyIG8cQlI5k3skB6ywaEA5F9f5OntrKKsT/Lteub2zgwSUlhqEN2inGgBTm8bpYJf8QYBdA/5naz65XDpczA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.3.tgz",
+      "integrity": "sha512-f+/WsED+xF4B74l3k9V/XkTVj5/fxFH2o5ToKXd8Iyi5UhM+sO9u0Ape17Mvl/GkZaFtM0HQnzAG5OTmhKw+tQ==",
       "dependencies": {
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
       }
     },
     "node_modules/mongoose": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.3.4.tgz",
-      "integrity": "sha512-UP0azyGMdY+2YNbJUHeHhnVw5vPzCqs4GQDUwHkilif/rwmSZktUQhQWMp1pUgRNeF2JC30vWGLrInZxD7K/Qw==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.5.1.tgz",
+      "integrity": "sha512-8C0213y279nrSp6Au+WB+l/VczcotMU65jalTJJxU6KYf/Kd8gNW9+B3giWNJOVd8VvKvUQG0suWv/Vngp/83A==",
       "dependencies": {
-        "bson": "^4.6.2",
-        "kareem": "2.3.5",
-        "mongodb": "4.5.0",
+        "bson": "^4.6.5",
+        "kareem": "2.4.1",
+        "mongodb": "4.8.1",
         "mpath": "0.9.0",
         "mquery": "4.0.3",
         "ms": "2.1.3",
@@ -13904,7 +13904,7 @@
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
-      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
       "optional": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
@@ -18233,9 +18233,9 @@
       "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
     },
     "@types/whatwg-url": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.1.tgz",
-      "integrity": "sha512-2YubE1sjj5ifxievI5Ge1sckb9k/Er66HyR2c+3+I6VDUUg1TLPdYYTEbQ+DjRkS4nTxMJhgWfSfMRD2sl2EYQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
       "requires": {
         "@types/node": "*",
         "@types/webidl-conversions": "*"
@@ -18748,9 +18748,9 @@
       }
     },
     "bson": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.4.tgz",
-      "integrity": "sha512-TdQ3FzguAu5HKPPlr0kYQCyrYUYh8tFM+CMTpxjNzVzxeiJY00Rtuj3LXLHSgiGvmaWlZ8PE+4KyM2thqE38pQ==",
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.5.tgz",
+      "integrity": "sha512-uqrgcjyOaZsHfz7ea8zLRCLe1u+QGUSzMZmvXqO24CDW7DWoW1qiN9folSwa7hSneTSgM2ykDIzF5kcQQ8cwNw==",
       "requires": {
         "buffer": "^5.6.0"
       }
@@ -19701,9 +19701,9 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "denque": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
-      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
     },
     "depd": {
       "version": "1.1.2",
@@ -22999,9 +22999,9 @@
       }
     },
     "kareem": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.5.tgz",
-      "integrity": "sha512-qxCyQtp3ioawkiRNQr/v8xw9KIviMSSNmy+63Wubj7KmMn3g7noRXIZB4vPCAP+ETi2SR8eH6CvmlKZuGpoHOg=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.4.1.tgz",
+      "integrity": "sha512-aJ9opVoXroQUPfovYP5kaj2lM7Jn02Gw13bL0lg9v0V7SaUc0qavPs0Eue7d2DcC3NjqI6QAUElXNsuZSeM+EA=="
     },
     "kind-of": {
       "version": "6.0.3",
@@ -23755,11 +23755,11 @@
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "mongodb": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.5.0.tgz",
-      "integrity": "sha512-A2l8MjEpKojnhbCM0MK3+UOGUSGvTNNSv7AkP1fsT7tkambrkkqN/5F2y+PhzsV0Nbv58u04TETpkaSEdI2zKA==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.8.1.tgz",
+      "integrity": "sha512-/NyiM3Ox9AwP5zrfT9TXjRKDJbXlLaUDQ9Rg//2lbg8D2A8GXV0VidYYnA/gfdK6uwbnL4FnAflH7FbGw3TS7w==",
       "requires": {
-        "bson": "^4.6.2",
+        "bson": "^4.6.5",
         "denque": "^2.0.1",
         "mongodb-connection-string-url": "^2.5.2",
         "saslprep": "^1.0.3",
@@ -23767,22 +23767,22 @@
       }
     },
     "mongodb-connection-string-url": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.2.tgz",
-      "integrity": "sha512-tWDyIG8cQlI5k3skB6ywaEA5F9f5OntrKKsT/Lteub2zgwSUlhqEN2inGgBTm8bpYJf8QYBdA/5naz65XDpczA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.3.tgz",
+      "integrity": "sha512-f+/WsED+xF4B74l3k9V/XkTVj5/fxFH2o5ToKXd8Iyi5UhM+sO9u0Ape17Mvl/GkZaFtM0HQnzAG5OTmhKw+tQ==",
       "requires": {
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
       }
     },
     "mongoose": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.3.4.tgz",
-      "integrity": "sha512-UP0azyGMdY+2YNbJUHeHhnVw5vPzCqs4GQDUwHkilif/rwmSZktUQhQWMp1pUgRNeF2JC30vWGLrInZxD7K/Qw==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.5.1.tgz",
+      "integrity": "sha512-8C0213y279nrSp6Au+WB+l/VczcotMU65jalTJJxU6KYf/Kd8gNW9+B3giWNJOVd8VvKvUQG0suWv/Vngp/83A==",
       "requires": {
-        "bson": "^4.6.2",
-        "kareem": "2.3.5",
-        "mongodb": "4.5.0",
+        "bson": "^4.6.5",
+        "kareem": "2.4.1",
+        "mongodb": "4.8.1",
         "mpath": "0.9.0",
         "mquery": "4.0.3",
         "ms": "2.1.3",
@@ -27078,7 +27078,7 @@
     "sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
-      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
       "optional": true,
       "requires": {
         "memory-pager": "^1.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@mojaloop/central-services-health": "14.0.1",
         "@mojaloop/central-services-logger": "11.0.1",
         "@mojaloop/central-services-metrics": "12.0.5",
-        "@mojaloop/central-services-shared": "17.0.2",
+        "@mojaloop/central-services-shared": "17.1.0",
         "@mojaloop/central-services-stream": "11.0.0",
         "@mojaloop/event-sdk": "11.0.2",
         "@mojaloop/ml-number": "11.2.1",
@@ -1734,9 +1734,9 @@
       }
     },
     "node_modules/@mojaloop/central-services-shared": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-17.0.2.tgz",
-      "integrity": "sha512-bXxOSqYdrojKtSbAlrUO8L8HsvaPcZAkU4xEWwQRh3pWIDKhAn5OMXZs3up1T6WmgupwBd7jlQQvxuj6EUsK4A==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-17.1.0.tgz",
+      "integrity": "sha512-Y2wghqU6NoeDlBkW0vzsEyJo/8xqYxQrhCLfeMzSgp/2A5k6cBvoStq4HgCrS0h9lfoAcDMaLV+I3WQ+mSzTEQ==",
       "dependencies": {
         "@hapi/catbox": "12.0.0",
         "@hapi/catbox-memory": "5.0.1",
@@ -1745,7 +1745,7 @@
         "dotenv": "16.0.1",
         "env-var": "7.1.1",
         "event-stream": "4.0.1",
-        "immutable": "4.0.0",
+        "immutable": "4.1.0",
         "lodash": "4.17.21",
         "mustache": "4.2.0",
         "openapi-backend": "5.3.0",
@@ -1754,7 +1754,7 @@
         "shins": "2.6.0",
         "uuid4": "2.0.2",
         "widdershins": "^4.0.1",
-        "yaml": "2.1.0"
+        "yaml": "2.1.1"
       },
       "engines": {
         "node": "=16.x"
@@ -7601,9 +7601,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
-      "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -10760,15 +10760,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm-check-updates/node_modules/yaml": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/npm-install-checks": {
@@ -16155,9 +16146,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.0.tgz",
-      "integrity": "sha512-OuAINfTsoJrY5H7CBWnKZhX6nZciXBydrMtTHr1dC4nP40X5jyTIVlogZHxSlVZM8zSgXRfgZGsaHF4+pV+JRw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
       "engines": {
         "node": ">= 14"
       }
@@ -17708,9 +17699,9 @@
       }
     },
     "@mojaloop/central-services-shared": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-17.0.2.tgz",
-      "integrity": "sha512-bXxOSqYdrojKtSbAlrUO8L8HsvaPcZAkU4xEWwQRh3pWIDKhAn5OMXZs3up1T6WmgupwBd7jlQQvxuj6EUsK4A==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-17.1.0.tgz",
+      "integrity": "sha512-Y2wghqU6NoeDlBkW0vzsEyJo/8xqYxQrhCLfeMzSgp/2A5k6cBvoStq4HgCrS0h9lfoAcDMaLV+I3WQ+mSzTEQ==",
       "requires": {
         "@hapi/catbox": "12.0.0",
         "@hapi/catbox-memory": "5.0.1",
@@ -17719,7 +17710,7 @@
         "dotenv": "16.0.1",
         "env-var": "7.1.1",
         "event-stream": "4.0.1",
-        "immutable": "4.0.0",
+        "immutable": "4.1.0",
         "lodash": "4.17.21",
         "mustache": "4.2.0",
         "openapi-backend": "5.3.0",
@@ -17728,7 +17719,7 @@
         "shins": "2.6.0",
         "uuid4": "2.0.2",
         "widdershins": "^4.0.1",
-        "yaml": "2.1.0"
+        "yaml": "2.1.1"
       },
       "dependencies": {
         "@hapi/catbox": {
@@ -22274,9 +22265,9 @@
       }
     },
     "immutable": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
-      "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -24627,12 +24618,6 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
           "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
-          "dev": true
-        },
-        "yaml": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-          "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
           "dev": true
         }
       }
@@ -28876,9 +28861,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.0.tgz",
-      "integrity": "sha512-OuAINfTsoJrY5H7CBWnKZhX6nZciXBydrMtTHr1dC4nP40X5jyTIVlogZHxSlVZM8zSgXRfgZGsaHF4+pV+JRw=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@mojaloop/central-services-health": "14.0.1",
     "@mojaloop/central-services-logger": "11.0.1",
     "@mojaloop/central-services-metrics": "12.0.5",
-    "@mojaloop/central-services-shared": "17.0.2",
+    "@mojaloop/central-services-shared": "17.1.0",
     "@mojaloop/central-services-stream": "11.0.0",
     "@mojaloop/event-sdk": "11.0.2",
     "@mojaloop/ml-number": "11.2.1",

--- a/src/handlers/bulk/shared/validator.js
+++ b/src/handlers/bulk/shared/validator.js
@@ -37,20 +37,31 @@
 const Participant = require('../../../domain/participant')
 const BulkTransferService = require('../../../domain/bulkTransfer')
 const Enum = require('@mojaloop/central-services-shared').Enum
+const ErrorHandler = require('@mojaloop/central-services-error-handling')
 
 const reasons = []
 
 const validateDifferentFsp = (payload) => {
   const isPayerAndPayeeDifferent = (payload.payerFsp.toLowerCase() !== payload.payeeFsp.toLowerCase())
   if (!isPayerAndPayeeDifferent) {
-    reasons.push('Payer and Payee should differ')
+    reasons.push(
+      ErrorHandler.Factory.createFSPIOPError(
+        ErrorHandler.Enums.FSPIOPErrorCodes.VALIDATION_ERROR,
+        'Payer and Payee should differ'
+      )
+    )
     return false
   }
   return true
 }
 const validateExpiration = (payload) => {
   if (Date.parse(payload.expiration) < Date.parse(new Date().toDateString())) {
-    reasons.push(`Expiration date ${new Date(payload.expiration.toString()).toISOString()} is already in the past`)
+    reasons.push(
+      ErrorHandler.Factory.createFSPIOPError(
+        ErrorHandler.Enums.FSPIOPErrorCodes.VALIDATION_ERROR,
+        `Expiration date ${new Date(payload.expiration.toString()).toISOString()} is already in the past`
+      )
+    )
     return false
   }
   return true
@@ -58,7 +69,12 @@ const validateExpiration = (payload) => {
 const validateFspiopSourceMatchesPayer = (payload, headers) => {
   const matched = (headers && headers[Enum.Http.Headers.FSPIOP.SOURCE] === payload.payerFsp)
   if (!matched) {
-    reasons.push('FSPIOP-Source header should match Payer')
+    reasons.push(
+      ErrorHandler.Factory.createFSPIOPError(
+        ErrorHandler.Enums.FSPIOPErrorCodes.VALIDATION_ERROR,
+        'FSPIOP-Source header should match Payer'
+      )
+    )
     return false
   }
   return true
@@ -68,24 +84,53 @@ const validateFspiopSourceAndDestination = async (payload, headers) => {
   const matchedPayee = (headers && headers[Enum.Http.Headers.FSPIOP.SOURCE] === participant.payeeFsp)
   const matchedPayer = (headers && headers[Enum.Http.Headers.FSPIOP.DESTINATION] === participant.payerFsp)
   if (!matchedPayee) {
-    reasons.push('FSPIOP-Source header should match Payee')
+    reasons.push(
+      ErrorHandler.Factory.createFSPIOPError(
+        ErrorHandler.Enums.FSPIOPErrorCodes.VALIDATION_ERROR,
+        'FSPIOP-Source header should match Payee'
+      )
+    )
     return false
   }
   if (!matchedPayer) {
-    reasons.push('FSPIOP-Destination header should match Payer')
+    reasons.push(
+      ErrorHandler.Factory.createFSPIOPError(
+        ErrorHandler.Enums.FSPIOPErrorCodes.VALIDATION_ERROR,
+        'FSPIOP-Destination header should match Payer'
+      )
+    )
     return false
   }
   return true
 }
-const validateParticipantByName = async (participantName) => {
+const validateParticipantByName = async (participantName, isPayer = null) => {
+  let fspiopErrorCode
+  if (isPayer == null) {
+    fspiopErrorCode = ErrorHandler.Enums.FSPIOPErrorCodes.VALIDATION_ERROR
+  } else if (isPayer) {
+    fspiopErrorCode = ErrorHandler.Enums.FSPIOPErrorCodes.PAYER_FSP_ID_NOT_FOUND
+  } else {
+    fspiopErrorCode = ErrorHandler.Enums.FSPIOPErrorCodes.PAYEE_FSP_ID_NOT_FOUND
+  }
+
   const participant = await Participant.getByName(participantName)
   let isValid = false
   let participantId
   if (!participant) {
-    reasons.push(`Participant ${participantName} not found`)
+    reasons.push(
+      ErrorHandler.Factory.createFSPIOPError(
+        fspiopErrorCode,
+        `Participant ${participantName} not found`
+      )
+    )
   } else if (!participant.isActive) {
     participantId = participant.participantId
-    reasons.push(`Participant ${participantName} is inactive`)
+    reasons.push(
+      ErrorHandler.Factory.createFSPIOPError(
+        fspiopErrorCode,
+        `Participant ${participantName} is inactive`
+      )
+    )
   } else {
     participantId = participant.participantId
     isValid = true
@@ -99,7 +144,12 @@ const validateBulkTransfer = async (payload, headers) => {
   let payerParticipantId = null
   let payeeParticipantId = null
   if (!payload) {
-    reasons.push('Bulk transfer must be provided')
+    reasons.push(
+      ErrorHandler.Factory.createFSPIOPError(
+        ErrorHandler.Enums.FSPIOPErrorCodes.VALIDATION_ERROR,
+        'Bulk transfer must be provided'
+      )
+    )
     isValid = false
     return { isValid, reasons, payerParticipantId, payeeParticipantId }
   }
@@ -107,7 +157,7 @@ const validateBulkTransfer = async (payload, headers) => {
   isValid = isValid && validateExpiration(payload)
   isValid = isValid && validateDifferentFsp(payload)
   if (isValid) {
-    const result = await validateParticipantByName(payload.payerFsp)
+    const result = await validateParticipantByName(payload.payerFsp, true)
     isValid = result.isValid
     payerParticipantId = result.participantId
   }
@@ -120,9 +170,16 @@ const validateBulkTransfer = async (payload, headers) => {
     // and body may be different. So we can not enforce that check.
 
     // We validate that both these fspId's exist and and continue on.
-    const payloadResult = await validateParticipantByName(payload.payeeFsp)
-    const headerResult = await validateParticipantByName(headers[Enum.Http.Headers.FSPIOP.DESTINATION])
-    isValid = payloadResult.isValid && headerResult.isValid
+    // We check the body then the header only if the body is valid to avoid
+    // adding two errors to `reasons`
+    const payloadResult = await validateParticipantByName(payload.payeeFsp, false)
+    isValid = payloadResult.isValid
+
+    if (isValid) {
+      const headerResult = await validateParticipantByName(headers[Enum.Http.Headers.FSPIOP.DESTINATION], false)
+      isValid = headerResult.isValid
+    }
+
     payeeParticipantId = payloadResult.participantId
   }
   return { isValid, reasons, payerParticipantId, payeeParticipantId }
@@ -132,7 +189,12 @@ const validateBulkTransferFulfilment = async (payload, headers) => {
   reasons.length = 0
   let isValid = true
   if (!payload) {
-    reasons.push('Bulk transfer fulfilment payload must be provided')
+    reasons.push(
+      ErrorHandler.Factory.createFSPIOPError(
+        ErrorHandler.Enums.FSPIOPErrorCodes.VALIDATION_ERROR,
+        'Bulk transfer fulfilment payload must be provided'
+      )
+    )
     isValid = false
     return { isValid, reasons }
   }

--- a/src/handlers/bulk/shared/validator.js
+++ b/src/handlers/bulk/shared/validator.js
@@ -47,7 +47,7 @@ const validateDifferentFsp = (payload) => {
     reasons.push(
       ErrorHandler.Factory.createFSPIOPError(
         ErrorHandler.Enums.FSPIOPErrorCodes.VALIDATION_ERROR,
-        'Payer and Payee should differ'
+        'Payer and Payee FSPs should be different'
       )
     )
     return false
@@ -72,7 +72,7 @@ const validateFspiopSourceMatchesPayer = (payload, headers) => {
     reasons.push(
       ErrorHandler.Factory.createFSPIOPError(
         ErrorHandler.Enums.FSPIOPErrorCodes.VALIDATION_ERROR,
-        'FSPIOP-Source header should match Payer'
+        'FSPIOP-Source header should match Payer FSP'
       )
     )
     return false
@@ -87,7 +87,7 @@ const validateFspiopSourceAndDestination = async (payload, headers) => {
     reasons.push(
       ErrorHandler.Factory.createFSPIOPError(
         ErrorHandler.Enums.FSPIOPErrorCodes.VALIDATION_ERROR,
-        'FSPIOP-Source header should match Payee'
+        'FSPIOP-Source header should match Payee FSP'
       )
     )
     return false
@@ -96,7 +96,7 @@ const validateFspiopSourceAndDestination = async (payload, headers) => {
     reasons.push(
       ErrorHandler.Factory.createFSPIOPError(
         ErrorHandler.Enums.FSPIOPErrorCodes.VALIDATION_ERROR,
-        'FSPIOP-Destination header should match Payer'
+        'FSPIOP-Destination header should match Payer FSP'
       )
     )
     return false
@@ -147,7 +147,7 @@ const validateBulkTransfer = async (payload, headers) => {
     reasons.push(
       ErrorHandler.Factory.createFSPIOPError(
         ErrorHandler.Enums.FSPIOPErrorCodes.VALIDATION_ERROR,
-        'Bulk transfer must be provided'
+        'A valid Bulk transfer message must be provided'
       )
     )
     isValid = false
@@ -192,7 +192,7 @@ const validateBulkTransferFulfilment = async (payload, headers) => {
     reasons.push(
       ErrorHandler.Factory.createFSPIOPError(
         ErrorHandler.Enums.FSPIOPErrorCodes.VALIDATION_ERROR,
-        'Bulk transfer fulfilment payload must be provided'
+        'A valid Bulk transfer fulfilment message must be provided'
       )
     )
     isValid = false


### PR DESCRIPTION
Rework bulk handler validator `reasons` string array to a `FSPIOPError` array to better specify error codes and descriptions.
Follow up PR for mojaloop/project#2800 mojaloop/project#2798

Test cases updated here https://github.com/mojaloop/testing-toolkit-test-cases/pull/79

Breaking changes:
The FSPIOP api errors for invalid/inactive/non-existant FSP's for **Bulk Transfers** are now updated to be more descriptive.
They have been updated to 
- ErrorHandler.Enums.FSPIOPErrorCodes.PAYER_FSP_ID_NOT_FOUND - 3202
- ErrorHandler.Enums.FSPIOPErrorCodes.PAYEE_FSP_ID_NOT_FOUND - 3203

If you have conditional logic based on error callbacks of POST /bulkTransfers you will need to update the error codes accordingly.